### PR TITLE
Dev/upgrade rustler

### DIFF
--- a/lib/html5ever/native.ex
+++ b/lib/html5ever/native.ex
@@ -3,7 +3,7 @@ defmodule NifNotLoadedError do
 end
 
 defmodule Html5ever.Native do
-  use Rustler, otp_app: :html5ever, crate: "html5ever_nif"
+  use Rustler, otp_app: :html5ever, crate: "html5ever_nif", mode: :release
 
   def parse_sync(_binary), do: err()
   def parse_async(_binary), do: err()
@@ -11,6 +11,6 @@ defmodule Html5ever.Native do
   def flat_parse_async(_binary), do: err()
 
   defp err() do
-    throw NifNotLoadedError
+    throw(NifNotLoadedError)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Html5ever.Mixfile do
 
   def project do
     [app: :html5ever,
-     version: "0.7.0",
+     version: "0.9.0",
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -7,24 +7,10 @@ defmodule Html5ever.Mixfile do
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     compilers: [:rustler] ++ Mix.compilers(),
-     rustler_crates: rustler_crates(),
+     compilers: Mix.compilers(),
      deps: deps(),
      description: description(),
      package: package()]
-  end
-
-  def rustler_crates do
-    [
-      html5ever_nif: [
-        path: "native/html5ever_nif",
-        cargo: :system,
-        default_features: false,
-        features: [],
-        mode: :release,
-        # mode: (if Mix.env == :prod, do: :release, else: :debug),
-      ]
-    ]
   end
 
   # Configuration for the OTP application

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule Html5ever.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:rustler, "0.22.0"},
+    [{:rustler, "~> 0.22.0"},
      {:ex_doc, ">= 0.0.0", only: :dev}]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Html5ever.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:rustler, "~> 0.21.0"},
+    [{:rustler, "0.22.0"},
      {:ex_doc, ">= 0.0.0", only: :dev}]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,9 @@
 %{
-  "earmark": {:hex, :earmark, "1.3.0", "17f0c38eaafb4800f746b457313af4b2442a8c2405b49c645768680f900be603", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "0.5.6", "da47b331b1fe0a5f0380cc3a6967200eac5e1daaa9c6bff4b0310b3fcc12b98f", [:mix], [{:nimble_parsec, "~> 0.4.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
-  "rustler": {:hex, :rustler, "0.21.0", "68cc4fc015d0b9541865ea78e78e9ef2dd91ee4be80bf543fd15791102a45aca", [:mix], [{:toml, "~> 0.5.2", [hex: :toml, repo: "hexpm", optional: false]}], "hexpm"},
-  "toml": {:hex, :toml, "0.5.2", "e471388a8726d1ce51a6b32f864b8228a1eb8edc907a0edf2bb50eab9321b526", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.0", "17f0c38eaafb4800f746b457313af4b2442a8c2405b49c645768680f900be603", [:mix], [], "hexpm", "f8b8820099caf0d5e72ae6482d2b0da96f213cbbe2b5b2191a37966e119eaa27"},
+  "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "dc87f778d8260da0189a622f62790f6202af72f2f3dee6e78d91a18dd2fcd137"},
+  "makeup": {:hex, :makeup, "0.5.6", "da47b331b1fe0a5f0380cc3a6967200eac5e1daaa9c6bff4b0310b3fcc12b98f", [:mix], [{:nimble_parsec, "~> 0.4.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "60ee0d5cc5f824ec62706ea705af4236dc1ff7422069a18b063f31863904c465"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "4a36dd2d0d5c5f98d95b3f410d7071cd661d5af310472229dd0e92161f168a44"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm", "ebb595e19456a72786db6dcd370d320350cb624f0b6203fcc7e23161d49b0ffb"},
+  "rustler": {:hex, :rustler, "0.22.0", "e2930f9d6933e910f87526bb0a7f904e32b62a7e838a3ca4a884ee7fdfb957ed", [:mix], [{:toml, "~> 0.5.2", [hex: :toml, repo: "hexpm", optional: false]}], "hexpm", "01f5989dd511ebec09be481e07d3c59773d5373c5061e09d3ebc3ef61811b49d"},
+  "toml": {:hex, :toml, "0.5.2", "e471388a8726d1ce51a6b32f864b8228a1eb8edc907a0edf2bb50eab9321b526", [:mix], [], "hexpm", "f1e3dabef71fb510d015fad18c0e05e7c57281001141504c6b69d94e99750a07"},
 }

--- a/native/html5ever_nif/Cargo.toml
+++ b/native/html5ever_nif/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/lib.rs"
 crate-type = ["dylib"]
 
 [dependencies]
-rustler = "^0.21"
+rustler = "^0.22"
 
 html5ever = "0.25"
 markup5ever = "0.10"

--- a/native/html5ever_nif/src/flat_dom.rs
+++ b/native/html5ever_nif/src/flat_dom.rs
@@ -292,24 +292,24 @@ impl Encoder for Node {
 }
 
 mod atoms {
-    rustler::rustler_atoms! {
-        atom nil;
+    rustler::atoms! {
+        nil,
 
-        atom type_ = "type";
-        atom document;
-        atom element;
-        atom text;
-        atom doctype;
-        atom comment;
+        type_ = "type",
+        document,
+        element,
+        text,
+        doctype,
+        comment,
 
-        atom name;
-        atom nodes;
-        atom root;
-        atom id;
-        atom parent;
-        atom children;
-        atom contents;
-        atom attrs;
+        name,
+        nodes,
+        root,
+        id,
+        parent,
+        children,
+        contents,
+        attrs,
     }
 }
 

--- a/native/html5ever_nif/src/lib.rs
+++ b/native/html5ever_nif/src/lib.rs
@@ -13,19 +13,19 @@ mod common;
 mod flat_dom;
 
 mod atoms {
-    rustler::rustler_atoms! {
-        atom html5ever_nif_result;
+    rustler::atoms! {
+        html5ever_nif_result,
 
-        atom ok;
-        atom error;
-        atom nif_panic;
+        ok,
+        error,
+        nif_panic,
 
-        atom doctype;
-        atom comment;
+        doctype,
+        comment,
 
-        atom none;
-        atom some;
-        atom all;
+        none,
+        some,
+        all,
     }
 }
 

--- a/native/html5ever_nif/src/lib.rs
+++ b/native/html5ever_nif/src/lib.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 
 use rustler::env::OwnedEnv;
 use rustler::types::binary::Binary;
-use rustler::{Decoder, Encoder, Env, Error, NifResult, Term, rustler_export_nifs};
+use rustler::{rustler_export_nifs, Decoder, Encoder, Env, Error, NifResult, Term};
 
 //use html5ever::rcdom::RcDom;
 use tendril::TendrilSink;
@@ -99,11 +99,7 @@ fn parse_async<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> {
                 let result = parser.one(std::str::from_utf8(binary.as_slice()).unwrap());
 
                 let result_term = flat_dom::flat_sink_to_rec_term(inner_env, &result);
-                (
-                    atoms::html5ever_nif_result(),
-                    atoms::ok(),
-                    result_term,
-                ).encode(inner_env)
+                (atoms::html5ever_nif_result(), atoms::ok(), result_term).encode(inner_env)
             }) {
                 Ok(term) => term,
                 Err(err) => {
@@ -169,11 +165,7 @@ fn flat_parse_async<'a>(env: Env<'a>, args: &[Term<'a>]) -> NifResult<Term<'a>> 
                 let result = parser.one(std::str::from_utf8(binary.as_slice()).unwrap());
 
                 let result_term = flat_dom::flat_sink_to_flat_term(inner_env, &result);
-                (
-                    atoms::html5ever_nif_result(),
-                    atoms::ok(),
-                    result_term,
-                ).encode(inner_env)
+                (atoms::html5ever_nif_result(), atoms::ok(), result_term).encode(inner_env)
             }) {
                 Ok(term) => term,
                 Err(err) => {


### PR DESCRIPTION
This pull request

- [x] Updates to use rustler 0.22
- [x] Update the rust code to use the new rustler atom macros
- [x] Update NIF function to use Derivable trait provided in rustler update
- [x] Remove config from mix.exs and move to consuming Elixir module
- [x] Update to use` rustler::init!` for exporting functions