### PR TITLE
Use a precompiled NIF

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,169 @@
+name: Build release
+
+env:
+  MIN_SUPPORTED_RUST_VERSION: "1.55.0"
+
+on:
+  push:
+    tags:
+      - '*'
+
+defaults:
+  run:
+    # Sets the working dir for "run" scripts.
+    # Note that this won't change the directory for actions (tasks with "uses").
+    working-directory: ./native/html5ever_nif
+
+jobs:
+  build_release:
+    name: NIF ${{ matrix.job.nif }} - ${{ matrix.job.target }} (${{ matrix.job.os }})
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          # NIF version 2.16
+          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04 , nif: "2.16", use-cross: true }
+          - { target: aarch64-apple-darwin        , os: macos-10.15  , nif: "2.16" }
+          - { target: x86_64-apple-darwin         , os: macos-10.15  , nif: "2.16" }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04 , nif: "2.16" }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04 , nif: "2.16", use-cross: true }
+          - { target: x86_64-pc-windows-gnu       , os: windows-2019 , nif: "2.16" }
+          - { target: x86_64-pc-windows-msvc      , os: windows-2019 , nif: "2.16" }
+          # NIF version 2.15
+          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04 , nif: "2.15", use-cross: true }
+          - { target: aarch64-apple-darwin        , os: macos-10.15  , nif: "2.15" }
+          - { target: x86_64-apple-darwin         , os: macos-10.15  , nif: "2.15" }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04 , nif: "2.15" }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04 , nif: "2.15", use-cross: true }
+          - { target: x86_64-pc-windows-gnu       , os: windows-2019 , nif: "2.15" }
+          - { target: x86_64-pc-windows-msvc      , os: windows-2019 , nif: "2.15" }
+          # NIF version 2.14
+          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04 , nif: "2.14", use-cross: true }
+          - { target: aarch64-apple-darwin        , os: macos-10.15  , nif: "2.14" }
+          - { target: x86_64-apple-darwin         , os: macos-10.15  , nif: "2.14" }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04 , nif: "2.14" }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04 , nif: "2.14", use-cross: true }
+          - { target: x86_64-pc-windows-gnu       , os: windows-2019 , nif: "2.14" }
+          - { target: x86_64-pc-windows-msvc      , os: windows-2019 , nif: "2.14" }
+
+    env:
+      RUSTLER_NIF_VERSION: ${{ matrix.job.nif }}
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v2
+
+    - name: Install prerequisites
+      shell: bash
+      run: |
+        case ${{ matrix.job.target }} in
+          arm-unknown-linux-*) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
+          aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
+        esac
+
+    - name: Extract crate information
+      shell: bash
+      run: |
+        echo "PROJECT_NAME=$(sed -n 's/^name = "\(.*\)"/\1/p' Cargo.toml | head -n1)" >> $GITHUB_ENV
+        # Get the project version from mix.exs
+        echo "PROJECT_VERSION=$(sed -n 's/^  @version "\(.*\)"/\1/p' ../../mix.exs | head -n1)" >> $GITHUB_ENV
+
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: ${{ matrix.job.target }}
+        override: true
+        profile: minimal
+
+    - name: Show version information (Rust, cargo, GCC)
+      shell: bash
+      run: |
+        gcc --version || true
+        rustup -V
+        rustup toolchain list
+        rustup default
+        cargo -V
+        rustc -V
+
+    - name: Download cross from GitHub releases
+      uses: giantswarm/install-binary-action@v1.0.0
+      if: ${{ matrix.job.use-cross }}
+      with:
+        binary: "cross"
+        version: "v0.2.1"
+        download_url: "https://github.com/rust-embedded/cross/releases/download/${version}/cross-${version}-x86_64-unknown-linux-gnu.tar.gz"
+        tarball_binary_path: "${binary}"
+        smoke_test: "${binary} --version"
+
+    - name: Build
+      shell: bash
+      run: |
+        if [ "${{ matrix.job.use-cross }}" == "true" ]; then
+          cross build --release --target=${{ matrix.job.target }}
+        else
+          cargo build --release --target=${{ matrix.job.target }}
+        fi
+
+    - name: Rename lib to the final name
+      id: rename
+      shell: bash
+      run: |
+        LIB_PREFIX="lib"
+        case ${{ matrix.job.target }} in
+          *-pc-windows-*) LIB_PREFIX="" ;;
+        esac;
+
+        # Figure out suffix of lib
+        # See: https://doc.rust-lang.org/reference/linkage.html
+        LIB_SUFFIX=".so"
+        case ${{ matrix.job.target }} in
+          *-apple-darwin) LIB_SUFFIX=".dylib" ;;
+          *-pc-windows-*) LIB_SUFFIX=".dll" ;;
+        esac;
+
+        CICD_INTERMEDIATES_DIR=$(mktemp -d) 
+
+        # Setup paths
+        LIB_DIR="${CICD_INTERMEDIATES_DIR}/released-lib"
+        mkdir -p "${LIB_DIR}"
+        LIB_NAME="${LIB_PREFIX}${{ env.PROJECT_NAME }}${LIB_SUFFIX}"
+        LIB_PATH="${LIB_DIR}/${LIB_NAME}"
+
+        # Copy the release build lib to the result location
+        cp "target/${{ matrix.job.target }}/release/${LIB_NAME}" "${LIB_DIR}"
+
+        # Final paths
+        # In the end we use ".so" for MacOS in the final build
+        # See: https://www.erlang.org/doc/man/erlang.html#load_nif-2
+        LIB_FINAL_SUFFIX="${LIB_SUFFIX}"
+        case ${{ matrix.job.target }} in
+          *-apple-darwin) LIB_FINAL_SUFFIX=".so" ;;
+        esac;
+
+        # Check Html5ever.Precompiled.target/0 - lib/html5ever/precompiled.ex 
+        LIB_FINAL_NAME="${LIB_PREFIX}${PROJECT_NAME}-v${PROJECT_VERSION}-nif-${RUSTLER_NIF_VERSION}-${{ matrix.job.target }}${LIB_FINAL_SUFFIX}"
+
+        # Copy lib to final name on this directory
+        cp "${LIB_PATH}" "${LIB_FINAL_NAME}"
+
+        tar -cvzf "${LIB_FINAL_NAME}.tar.gz" "${LIB_FINAL_NAME}"
+
+        # Passes the path relative to the root of the project.
+        LIB_FINAL_PATH="native/html5ever_nif/${LIB_FINAL_NAME}.tar.gz"
+
+        # Let subsequent steps know where to find the lib
+        echo ::set-output name=LIB_FINAL_PATH::${LIB_FINAL_PATH}
+        echo ::set-output name=LIB_FINAL_NAME::${LIB_FINAL_NAME}.tar.gz
+
+    - name: "Artifact upload"
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ steps.rename.outputs.LIB_FINAL_NAME }}
+        path: ${{ steps.rename.outputs.LIB_FINAL_PATH }}
+
+    - name: Publish archives and packages
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          ${{ steps.rename.outputs.LIB_FINAL_PATH }}

--- a/README.md
+++ b/README.md
@@ -16,9 +16,14 @@ def deps do
 end
 ```
 
-By default you don't need Rust installed because the lib will try to download
+By default **you don't need Rust installed** because the lib will try to download
 a precompiled NIF file. In case you want to force compilation set the
-`HTML5EVER_BUILD` env var to `true` or `1`.
+`HTML5EVER_BUILD` environment variable to `true` or `1`. Alternatively you can also set the
+application env `:skip_compilation?` to `false` in order to force the build:
+
+```elixir
+config :html5ever, Html5ever.Native, skip_compilation?: false
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ end
 By default **you don't need Rust installed** because the lib will try to download
 a precompiled NIF file. In case you want to force compilation set the
 `HTML5EVER_BUILD` environment variable to `true` or `1`. Alternatively you can also set the
-application env `:skip_compilation?` to `false` in order to force the build:
+application env `:build_from_source` to `true` in order to force the build:
 
 ```elixir
-config :html5ever, Html5ever.Native, skip_compilation?: false
+config :html5ever, Html5ever, build_from_source: true
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ def deps do
 end
 ```
 
+By default you don't need Rust installed because the lib will try to download
+a precompiled NIF file. In case you want to force compilation set the
+`HTML5EVER_BUILD` env var to `true` or `1`.
+
 ## License
 
 Licensed under either of

--- a/lib/html5ever.ex
+++ b/lib/html5ever.ex
@@ -1,6 +1,15 @@
 defmodule Html5ever do
   @moduledoc """
   The html5ever is an HTML parser written in Rust.
+
+  By default this lib will try to use a precompiled NIF
+  from the GitHub releases page. This way you don't need
+  to have the Rust toolchain installed.
+  In case no precompiled file is found an error is raised.
+
+  You can force the precompilation to occur by setting the
+  value of the `HTML5EVER_BUILD` environment variable to
+  "true" or "1".
   """
 
   @doc """

--- a/lib/html5ever/native.ex
+++ b/lib/html5ever/native.ex
@@ -7,11 +7,10 @@ defmodule Html5ever.Native do
   # @github_url mix_config[:package][:links]["GitHub"]
 
   rustler_opts = [otp_app: :html5ever, crate: "html5ever_nif", mode: :release]
-  env_config = Application.get_env(rustler_opts[:otp_app], __MODULE__, [])
+  env_config = Application.get_env(rustler_opts[:otp_app], Html5ever, [])
 
   opts =
-    if System.get_env("HTML5EVER_BUILD") in ["1", "true"] or
-         env_config[:skip_compilation?] === false do
+    if System.get_env("HTML5EVER_BUILD") in ["1", "true"] or env_config[:build_from_source] do
       rustler_opts
     else
       case Html5ever.Precompiled.download_or_reuse_nif_file(
@@ -27,7 +26,7 @@ defmodule Html5ever.Native do
 
         {:error, error} ->
           error =
-            "Error while downloading precompiled NIF: #{error}\n\nSet HTML5EVER_BUILD=1 env var to compile the NIF from scratch. You can also configure this application to force compilation:\n\n    config :html5ever, Html5ever.Native, skip_compilation?: false\n"
+            "Error while downloading precompiled NIF: #{error}\n\nSet HTML5EVER_BUILD=1 env var to compile the NIF from scratch. You can also configure this application to force compilation:\n\n    config :html5ever, Html5ever, build_from_source: true\n"
 
           if Mix.env() == :prod do
             raise error

--- a/lib/html5ever/native.ex
+++ b/lib/html5ever/native.ex
@@ -1,9 +1,44 @@
 defmodule Html5ever.Native do
   @moduledoc false
+  require Logger
+
+  mix_config = Mix.Project.config()
+  @version mix_config[:version]
+  # @github_url mix_config[:package][:links]["GitHub"]
+
+  rustler_opts = [otp_app: :html5ever, crate: "html5ever_nif", mode: :release]
+
+  opts =
+    if System.get_env("HTML5EVER_BUILD") in ["1", "true"] do
+      rustler_opts
+    else
+      case Html5ever.Precompiled.download_or_reuse_nif_file(
+             rustler_opts,
+             # TODO: change to the following before merging PR
+             # base_url: "#{@github_url}/releases/download/v#{@version}",
+             base_url:
+               "https://github.com/philss/html5ever_elixir/releases/download/testing-release33",
+             version: @version
+           ) do
+        {:ok, new_opts} ->
+          new_opts
+
+        {:error, error} ->
+          error =
+            "Error while downloading precompiled NIF: #{error}. Set HTML5EVER_BUILD=1 to compile the NIF from scratch"
+
+          if Mix.env() == :prod do
+            raise error
+          else
+            Logger.debug(error)
+            rustler_opts
+          end
+      end
+    end
 
   # This module will be replaced by the NIF module after
   # loaded. It throws an error in case the NIF can't be loaded.
-  use Rustler, otp_app: :html5ever, crate: "html5ever_nif", mode: :release
+  use Rustler, opts
 
   def parse_sync(_binary), do: err()
   def parse_async(_binary), do: err()

--- a/lib/html5ever/native.ex
+++ b/lib/html5ever/native.ex
@@ -4,7 +4,7 @@ defmodule Html5ever.Native do
 
   mix_config = Mix.Project.config()
   version = mix_config[:version]
-  # @github_url mix_config[:package][:links]["GitHub"]
+  github_url = mix_config[:package][:links]["GitHub"]
 
   rustler_opts = [otp_app: :html5ever, crate: "html5ever_nif", mode: :release]
   env_config = Application.get_env(rustler_opts[:otp_app], Html5ever, [])
@@ -15,10 +15,7 @@ defmodule Html5ever.Native do
     else
       case Html5ever.Precompiled.download_or_reuse_nif_file(
              rustler_opts,
-             # TODO: change to the following before merging PR
-             # base_url: "#{@github_url}/releases/download/v#{@version}",
-             base_url:
-               "https://github.com/philss/html5ever_elixir/releases/download/testing-release33",
+             base_url: "#{github_url}/releases/download/v#{version}",
              version: version
            ) do
         {:ok, new_opts} ->

--- a/lib/html5ever/native.ex
+++ b/lib/html5ever/native.ex
@@ -27,7 +27,7 @@ defmodule Html5ever.Native do
 
         {:error, error} ->
           error =
-            "Error while downloading precompiled NIF: #{error}. Set HTML5EVER_BUILD=1 to compile the NIF from scratch"
+            "Error while downloading precompiled NIF: #{error}\n\nSet HTML5EVER_BUILD=1 env var to compile the NIF from scratch. You can also configure this application to force compilation:\n\n    config :html5ever, Html5ever.Native, skip_compilation?: false\n"
 
           if Mix.env() == :prod do
             raise error

--- a/lib/html5ever/native.ex
+++ b/lib/html5ever/native.ex
@@ -3,13 +3,15 @@ defmodule Html5ever.Native do
   require Logger
 
   mix_config = Mix.Project.config()
-  @version mix_config[:version]
+  version = mix_config[:version]
   # @github_url mix_config[:package][:links]["GitHub"]
 
   rustler_opts = [otp_app: :html5ever, crate: "html5ever_nif", mode: :release]
+  env_config = Application.get_env(rustler_opts[:otp_app], __MODULE__, [])
 
   opts =
-    if System.get_env("HTML5EVER_BUILD") in ["1", "true"] do
+    if System.get_env("HTML5EVER_BUILD") in ["1", "true"] or
+         env_config[:skip_compilation?] === false do
       rustler_opts
     else
       case Html5ever.Precompiled.download_or_reuse_nif_file(
@@ -18,7 +20,7 @@ defmodule Html5ever.Native do
              # base_url: "#{@github_url}/releases/download/v#{@version}",
              base_url:
                "https://github.com/philss/html5ever_elixir/releases/download/testing-release33",
-             version: @version
+             version: version
            ) do
         {:ok, new_opts} ->
           new_opts

--- a/lib/html5ever/precompiled.ex
+++ b/lib/html5ever/precompiled.ex
@@ -1,0 +1,303 @@
+defmodule Html5ever.Precompiled do
+  @moduledoc false
+
+  require Logger
+
+  @available_targets ~w(
+    aarch64-apple-darwin
+    x86_64-apple-darwin
+    x86_64-unknown-linux-gnu
+    x86_64-unknown-linux-musl
+    arm-unknown-linux-gnueabihf
+    x86_64-pc-windows-msvc
+    x86_64-pc-windows-gnu
+  )
+  @available_nif_versions ~w(2.14 2.15 2.16)
+
+  @doc """
+  Returns the target triple for download or compile and load.
+
+  This function is translating and adding more info to the system
+  architecture returned by Elixir/Erlang to one used by Rust.
+
+  The returning string format is the following:
+
+    "nif-NIF_VERSION-ARCHITECTURE-VENDOR-OS-ABI"
+
+  ## Examples
+
+      iex> target()
+      {:ok, "nif-2.16-x86_64-unknown-linux-gnu"} 
+
+      iex> target()
+      {:ok, "nif-2.15-aarch64-apple-darwin"}
+
+  """
+  def target(config \\ target_config()) do
+    sys_arch = maybe_override_with_env_vars(config.system_arch)
+
+    arch_os =
+      case config.os_type do
+        {:unix, os} ->
+          os
+          |> normalize_arch_os(sys_arch)
+          |> system_arch_to_string()
+
+        {:win32, _} ->
+          # 32 or 64 bits
+          arch =
+            case config.word_size do
+              4 -> "i686"
+              8 -> "x86_64"
+              _ -> "unknown"
+            end
+
+          sys_arch
+          |> Map.put_new(:arch, arch)
+          |> Map.put_new(:vendor, "pc")
+          |> Map.put_new(:os, "windows")
+          |> Map.put_new(:abi, "msvc")
+          |> system_arch_to_string()
+      end
+
+    cond do
+      arch_os not in @available_targets ->
+        {:error,
+         "precompiled NIF is not available for this target: #{inspect(arch_os)}. The available targets are:\n - #{Enum.join(@available_targets, "\n - ")}"}
+
+      config.nif_version not in @available_nif_versions ->
+        {:error,
+         "precompiled NIF is not available for this NIF version: #{inspect(config.nif_version)}. The available NIF versions are:\n - #{Enum.join(@available_nif_versions, "\n - ")}"}
+
+      true ->
+        {:ok, "nif-#{config.nif_version}-#{arch_os}"}
+    end
+  end
+
+  defp target_config do
+    current_nif_version = :erlang.system_info(:nif_version) |> List.to_string()
+
+    %{
+      os_type: :os.type(),
+      system_arch: system_arch(),
+      word_size: :erlang.system_info(:wordsize),
+      nif_version: find_compatible_nif_version(current_nif_version, @available_nif_versions)
+    }
+  end
+
+  # In case one is using this lib in a newer OTP version, we try to
+  # find the latest compatible NIF version.
+  defp find_compatible_nif_version(vsn, available) do
+    if vsn in available do
+      vsn
+    else
+      [major | _] = String.split(vsn, ".")
+
+      available
+      |> Enum.filter(fn vsn -> String.starts_with?(vsn, major <> ".") end)
+      |> Enum.max_by(fn vsn -> vsn |> String.split(".") |> Enum.map(&String.to_integer/1) end)
+    end
+  end
+
+  # Returns a map with `:arch`, `:vendor`, `:os` and maybe `:abi`.
+  defp system_arch do
+    base =
+      :erlang.system_info(:system_architecture)
+      |> List.to_string()
+      |> String.split("-")
+
+    triple_keys =
+      case length(base) do
+        4 ->
+          [:arch, :vendor, :os, :abi]
+
+        3 ->
+          [:arch, :vendor, :os]
+
+        _ ->
+          # It's too complicated to find out, and we won't support this for now.
+          []
+      end
+
+    triple_keys
+    |> Enum.zip(base)
+    |> Enum.into(%{})
+  end
+
+  # The idea is to support systems like Nerves.
+  # See: https://hexdocs.pm/nerves/compiling-non-beam-code.html#target-cpu-arch-os-and-abi
+  defp maybe_override_with_env_vars(system_arch) do
+    envs_with_keys = [arch: "TARGET_ARCH", os: "TARGET_OS", abi: "TARGET_ABI"]
+
+    Enum.reduce(envs_with_keys, system_arch, fn {key, env_key}, acc ->
+      if env_value = System.get_env(env_key) do
+        Map.put(acc, key, env_value)
+      else
+        acc
+      end
+    end)
+  end
+
+  defp normalize_arch_os(:darwin, sys_arch) do
+    arch = with "arm" <- sys_arch.arch, do: "aarch64"
+
+    %{sys_arch | arch: arch, os: "darwin"}
+  end
+
+  defp normalize_arch_os(:linux, sys_arch) do
+    arch = with "amd64" <- sys_arch.arch, do: "x86_64"
+    vendor = with "pc" <- sys_arch.vendor, do: "unknown"
+
+    # Fix vendor for Nerves
+    vendor =
+      if arch == "arm" and vendor == "buildroot" do
+        "unknown"
+      else
+        vendor
+      end
+
+    %{sys_arch | arch: arch, vendor: vendor}
+  end
+
+  defp normalize_arch_os(_other, sys_arch), do: sys_arch
+
+  defp system_arch_to_string(system_arch) do
+    values =
+      for key <- [:arch, :vendor, :os, :abi],
+          value = system_arch[key],
+          do: value
+
+    Enum.join(values, "-")
+  end
+
+  def download_or_reuse_nif_file(rustler_opts, opts) do
+    name = Keyword.fetch!(rustler_opts, :otp_app)
+    version = Keyword.fetch!(opts, :version)
+
+    priv_dir = Application.app_dir(name, "priv")
+
+    cache_opts = if System.get_env("MIX_XDG"), do: %{os: :linux}, else: %{}
+    cache_dir = :filename.basedir(:user_cache, Atom.to_string(name), cache_opts)
+
+    with {:ok, target} <- target() do
+      nif_name = rustler_opts[:crate] || name
+      lib_name = "#{lib_prefix(target)}#{nif_name}-v#{version}-#{target}"
+
+      file_name = lib_name_with_ext(target, lib_name)
+      cached_tar_gz = Path.join(cache_dir, "#{file_name}.tar.gz")
+
+      lib_file =
+        priv_dir
+        |> Path.join("native")
+        |> Path.join(file_name)
+
+      # Override Rustler opts so we load from the downloaded file.
+      # See: https://hexdocs.pm/rustler/Rustler.html#module-configuration-options 
+      new_opts =
+        rustler_opts
+        |> Keyword.put(:skip_compilation?, true)
+        |> Keyword.put(:load_from, {name, "priv/native/#{lib_name}"})
+
+      cond do
+        File.exists?(lib_file) ->
+          Logger.debug("Using NIF from #{lib_file}")
+          {:ok, new_opts}
+
+        File.exists?(cached_tar_gz) ->
+          with :ok <- :erl_tar.extract(cached_tar_gz, [:compressed, cwd: Path.dirname(lib_file)]) do
+            Logger.debug("Copying NIF from cache and extracting to #{lib_file}")
+            {:ok, new_opts}
+          end
+
+        true ->
+          base_url = Keyword.fetch!(opts, :base_url)
+          dirname = Path.dirname(lib_file)
+
+          with :ok <- File.mkdir_p(cache_dir),
+               :ok <- File.mkdir_p(dirname),
+               {:ok, tar_gz} <- download_tar_gz(base_url, lib_name, cached_tar_gz),
+               :ok <-
+                 :erl_tar.extract({:binary, tar_gz}, [:compressed, cwd: Path.dirname(lib_file)]) do
+            Logger.debug("NIF cached at #{cached_tar_gz} and extracted to #{lib_file}")
+            {:ok, new_opts}
+          end
+      end
+    end
+  end
+
+  defp lib_prefix(target) do
+    if String.contains?(target, "windows") do
+      ""
+    else
+      "lib"
+    end
+  end
+
+  defp lib_name_with_ext(target, lib_name) do
+    ext =
+      if String.contains?(target, "windows") do
+        "dll"
+      else
+        "so"
+      end
+
+    "#{lib_name}.#{ext}"
+  end
+
+  defp download_tar_gz(base_url, lib_name, target_name) do
+    uri = URI.parse(base_url)
+
+    uri =
+      Map.update!(uri, :path, fn path ->
+        "#{path}/#{lib_name_with_ext(target_name, lib_name)}.tar.gz"
+      end)
+
+    download_nif_artifact(to_string(uri))
+  end
+
+  # Gets the NIF file from a given URL.
+  defp download_nif_artifact(url) do
+    url = String.to_charlist(url)
+    Logger.debug("Downloading NIF from #{url}")
+
+    {:ok, _} = Application.ensure_all_started(:inets)
+    {:ok, _} = Application.ensure_all_started(:ssl)
+
+    if proxy = System.get_env("HTTP_PROXY") || System.get_env("http_proxy") do
+      Logger.debug("Using HTTP_PROXY: #{proxy}")
+      %{host: host, port: port} = URI.parse(proxy)
+
+      :httpc.set_options([{:proxy, {{String.to_charlist(host), port}, []}}])
+    end
+
+    if proxy = System.get_env("HTTPS_PROXY") || System.get_env("https_proxy") do
+      Logger.debug("Using HTTPS_PROXY: #{proxy}")
+      %{host: host, port: port} = URI.parse(proxy)
+      :httpc.set_options([{:https_proxy, {{String.to_charlist(host), port}, []}}])
+    end
+
+    # https://erlef.github.io/security-wg/secure_coding_and_deployment_hardening/inets
+    cacertfile = CAStore.file_path() |> String.to_charlist()
+
+    http_options = [
+      ssl: [
+        verify: :verify_peer,
+        cacertfile: cacertfile,
+        depth: 2,
+        customize_hostname_check: [
+          match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+        ]
+      ]
+    ]
+
+    options = [body_format: :binary]
+
+    case :httpc.request(:get, {url, []}, http_options, options) do
+      {:ok, {{_, 200, _}, _headers, body}} ->
+        {:ok, body}
+
+      other ->
+        {:error, "couldn't fetch NIF from #{url}: #{inspect(other)}"}
+    end
+  end
+end

--- a/lib/html5ever/precompiled.ex
+++ b/lib/html5ever/precompiled.ex
@@ -63,11 +63,11 @@ defmodule Html5ever.Precompiled do
     cond do
       arch_os not in @available_targets ->
         {:error,
-         "precompiled NIF is not available for this target: #{inspect(arch_os)}. The available targets are:\n - #{Enum.join(@available_targets, "\n - ")}"}
+         "precompiled NIF is not available for this target: #{inspect(arch_os)}.\nThe available targets are:\n - #{Enum.join(@available_targets, "\n - ")}"}
 
       config.nif_version not in @available_nif_versions ->
         {:error,
-         "precompiled NIF is not available for this NIF version: #{inspect(config.nif_version)}. The available NIF versions are:\n - #{Enum.join(@available_nif_versions, "\n - ")}"}
+         "precompiled NIF is not available for this NIF version: #{inspect(config.nif_version)}.\nThe available NIF versions are:\n - #{Enum.join(@available_nif_versions, "\n - ")}"}
 
       true ->
         {:ok, "nif-#{config.nif_version}-#{arch_os}"}

--- a/mix.exs
+++ b/mix.exs
@@ -20,12 +20,13 @@ defmodule Html5ever.Mixfile do
   end
 
   def application do
-    [extra_applications: [:logger]]
+    [extra_applications: [:logger, :inets, :public_key]]
   end
 
   defp deps do
     [
       {:rustler, "~> 0.22.0"},
+      {:castore, "~> 0.1"},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "castore": {:hex, :castore, "0.1.13", "ccf3ab251ffaebc4319f41d788ce59a6ab3f42b6c27e598ad838ffecee0b04f9", [:mix], [], "hexpm", "a14a7eecfec7e20385493dbb92b0d12c5d77ecfd6307de10102d58c94e8c49c0"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.17", "6f3c7e94170377ba45241d394389e800fb15adc5de51d0a3cd52ae766aafd63f", [:mix], [], "hexpm", "f93ac89c9feca61c165b264b5837bf82344d13bebc634cd575cb711e2e342023"},
   "ex_doc": {:hex, :ex_doc, "0.26.0", "1922164bac0b18b02f84d6f69cab1b93bc3e870e2ad18d5dacb50a9e06b542a3", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "2775d66e494a9a48355db7867478ffd997864c61c65a47d31c4949459281c78d"},
   "jason": {:hex, :jason, "1.2.2", "ba43e3f2709fd1aa1dce90aaabfd039d000469c05c56f0b8e31978e03fa39052", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "18a228f5f0058ee183f29f9eae0805c6e59d61c3b006760668d8d18ff0d12179"},

--- a/native/html5ever_nif/.cargo/config
+++ b/native/html5ever_nif/.cargo/config
@@ -9,3 +9,12 @@ rustflags = [
   "-C", "link-arg=-undefined",
   "-C", "link-arg=dynamic_lookup",
 ]
+
+[target.arm-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"
+
+# See https://github.com/rust-lang/rust/issues/59302
+[target.x86_64-unknown-linux-musl]
+rustflags = [
+  "-C", "target-feature=-crt-static"
+]

--- a/native/html5ever_nif/Cargo.lock
+++ b/native/html5ever_nif/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +119,12 @@ dependencies = [
  "string_cache_codegen",
  "tendril",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -237,10 +252,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
 name = "rustler"
 version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08281b5931d395414fe2e3e786d4b21dbcffc18d848d542d8a2da03026cb7cb8"
+source = "git+https://github.com/rusterlium/rustler#e6cfd2ab42ae567fac3cdb1d3a4b84de01a3531c"
 dependencies = [
  "lazy_static",
  "rustler_codegen",
@@ -250,8 +281,7 @@ dependencies = [
 [[package]]
 name = "rustler_codegen"
 version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96f4adf61752ab8c56df102591ff97c93d4e5c7a9ff04b82cdfa85dfa072544c"
+source = "git+https://github.com/rusterlium/rustler#e6cfd2ab42ae567fac3cdb1d3a4b84de01a3531c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -262,9 +292,9 @@ dependencies = [
 [[package]]
 name = "rustler_sys"
 version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb382fde4f421c51555919e9920b058c0286f6bf59e53d02eb4d281eae6758b"
+source = "git+https://github.com/rusterlium/rustler#e6cfd2ab42ae567fac3cdb1d3a4b84de01a3531c"
 dependencies = [
+ "regex",
  "unreachable",
 ]
 

--- a/native/html5ever_nif/Cargo.toml
+++ b/native/html5ever_nif/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 [lib]
 name = "html5ever_nif"
 path = "src/lib.rs"
-crate-type = ["dylib"]
+crate-type = ["cdylib"]
 
 [dependencies]
-rustler = "^0.22"
+rustler = { git = "https://github.com/rusterlium/rustler" }
 
 html5ever = "0.25"
 markup5ever = "0.10"

--- a/test/html5ever/precompiled_test.exs
+++ b/test/html5ever/precompiled_test.exs
@@ -58,7 +58,7 @@ defmodule Html5ever.PrecompiledTest do
     }
 
     error_message =
-      "precompiled NIF is not available for this target: \"i686-unknown-linux-gnu\". The available targets are:\n - aarch64-apple-darwin\n - x86_64-apple-darwin\n - x86_64-unknown-linux-gnu\n - x86_64-unknown-linux-musl\n - arm-unknown-linux-gnueabihf\n - x86_64-pc-windows-msvc\n - x86_64-pc-windows-gnu"
+      "precompiled NIF is not available for this target: \"i686-unknown-linux-gnu\".\nThe available targets are:\n - aarch64-apple-darwin\n - x86_64-apple-darwin\n - x86_64-unknown-linux-gnu\n - x86_64-unknown-linux-musl\n - arm-unknown-linux-gnueabihf\n - x86_64-pc-windows-msvc\n - x86_64-pc-windows-gnu"
 
     assert {:error, ^error_message} = Precompiled.target(config)
   end

--- a/test/html5ever/precompiled_test.exs
+++ b/test/html5ever/precompiled_test.exs
@@ -62,4 +62,20 @@ defmodule Html5ever.PrecompiledTest do
 
     assert {:error, ^error_message} = Precompiled.target(config)
   end
+
+  test "find_compatible_nif_version/2" do
+    available = ~w(2.14 2.15 2.16)
+
+    assert Precompiled.find_compatible_nif_version("2.14", available) == {:ok, "2.14"}
+    assert Precompiled.find_compatible_nif_version("2.15", available) == {:ok, "2.15"}
+    assert Precompiled.find_compatible_nif_version("2.16", available) == {:ok, "2.16"}
+    assert Precompiled.find_compatible_nif_version("2.17", available) == {:ok, "2.16"}
+    assert Precompiled.find_compatible_nif_version("2.13", available) == :error
+    assert Precompiled.find_compatible_nif_version("3.0", available) == :error
+    assert Precompiled.find_compatible_nif_version("1.0", available) == :error
+
+    assert Precompiled.find_compatible_nif_version("2.14", ["2.14"]) == {:ok, "2.14"}
+    assert Precompiled.find_compatible_nif_version("2.17", ["2.14"]) == {:ok, "2.14"}
+    assert Precompiled.find_compatible_nif_version("2.13", ["2.14"]) == :error
+  end
 end

--- a/test/html5ever/precompiled_test.exs
+++ b/test/html5ever/precompiled_test.exs
@@ -1,0 +1,65 @@
+defmodule Html5ever.PrecompiledTest do
+  use ExUnit.Case, async: true
+  alias Html5ever.Precompiled
+
+  test "target/1" do
+    config = %{
+      system_arch: %{arch: "arm", vendor: "apple", os: "darwin20.3.0"},
+      nif_version: "2.16",
+      os_type: {:unix, :darwin}
+    }
+
+    assert {:ok, "nif-2.16-aarch64-apple-darwin"} = Precompiled.target(config)
+
+    config = %{
+      config
+      | system_arch: %{arch: "x86_64", vendor: "apple", os: "darwin20.3.0"},
+        nif_version: "2.15"
+    }
+
+    assert {:ok, "nif-2.15-x86_64-apple-darwin"} = Precompiled.target(config)
+
+    config = %{
+      system_arch: %{arch: "amd64", vendor: "pc", os: "linux", abi: "gnu"},
+      nif_version: "2.14",
+      os_type: {:unix, :linux}
+    }
+
+    assert {:ok, "nif-2.14-x86_64-unknown-linux-gnu"} = Precompiled.target(config)
+
+    config = %{
+      config
+      | system_arch: %{arch: "x86_64", vendor: "unknown", os: "linux", abi: "gnu"}
+    }
+
+    assert {:ok, "nif-2.14-x86_64-unknown-linux-gnu"} = Precompiled.target(config)
+
+    config = %{
+      system_arch: %{arch: "arm", vendor: "buildroot", os: "linux", abi: "gnueabihf"},
+      nif_version: "2.16",
+      os_type: {:unix, :linux}
+    }
+
+    assert {:ok, "nif-2.16-arm-unknown-linux-gnueabihf"} = Precompiled.target(config)
+
+    config = %{
+      system_arch: %{},
+      word_size: 8,
+      nif_version: "2.14",
+      os_type: {:win32, :nt}
+    }
+
+    assert {:ok, "nif-2.14-x86_64-pc-windows-msvc"} = Precompiled.target(config)
+
+    config = %{
+      system_arch: %{arch: "i686", vendor: "unknown", os: "linux", abi: "gnu"},
+      nif_version: "2.14",
+      os_type: {:unix, :linux}
+    }
+
+    error_message =
+      "precompiled NIF is not available for this target: \"i686-unknown-linux-gnu\". The available targets are:\n - aarch64-apple-darwin\n - x86_64-apple-darwin\n - x86_64-unknown-linux-gnu\n - x86_64-unknown-linux-musl\n - arm-unknown-linux-gnueabihf\n - x86_64-pc-windows-msvc\n - x86_64-pc-windows-gnu"
+
+    assert {:error, ^error_message} = Precompiled.target(config)
+  end
+end


### PR DESCRIPTION
This PR introduces the ability to download a precompiled NIF and remove the need of having the Rust toolchain installed.

It is going to work for the majority of popular Operational Systems.
The following [targets](https://doc.rust-lang.org/cargo/appendix/glossary.html#target) are supported:
- aarch64-apple-darwin - MacOS on M1
- x86_64-apple-darwin
- x86_64-unknown-linux-gnu
- x86_64-unknown-linux-musl 
- arm-unknown-linux-gnueabihf
- x86_64-pc-windows-gnu
- x86_64-pc-windows-msvc

You can play with it using this snippet (requires Elixir ~> 1.12):

```elixir
Mix.install([
  {:html5ever,
   git: "https://github.com/philss/html5ever_elixir.git", branch: "ps-download-precompiled"}
])

html = """
<!doctype html>
<html>
  <head><title>Testing</title></head>
  <body><h1>Hello world</h1></body>
</html>
"""

Html5ever.parse(html)
```

## The Release workflow

Most of the work is done by the CI server, which in this case is GitHub Actions.
Upon each new pushed tag we trigger the "release" workflow - which is independent of Hex.
That workflow is going to build the NIF files and upload to the release page. We use the tool ["cross"](https://github.com/rust-embedded/cross) to help with some of the cross compilations.

You can see one of the releases here: https://github.com/philss/html5ever_elixir/releases/tag/testing-release30

The "release" workflow was heavily inspired by this: https://github.com/sharkdp/lscolors/blob/c6e191b91f637058ba932a4f7b065f2e19d8a1ba/.github/workflows/CICD.yml

## Open questions

- Should we compress the files (tar.gz)?
- Should we include the license files together?
- In case the precompiled NIF is not available, should we always force a compilation? Today we raise an error.