### PR TITLE
Add support for precompiled ARM 64-bits on Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         job:
           # NIF version 2.16
           - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04 , nif: "2.16", use-cross: true }
+          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04 , nif: "2.16", use-cross: true }
           - { target: aarch64-apple-darwin        , os: macos-10.15  , nif: "2.16" }
           - { target: x86_64-apple-darwin         , os: macos-10.15  , nif: "2.16" }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04 , nif: "2.16" }
@@ -32,6 +33,7 @@ jobs:
           - { target: x86_64-pc-windows-msvc      , os: windows-2019 , nif: "2.16" }
           # NIF version 2.15
           - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04 , nif: "2.15", use-cross: true }
+          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04 , nif: "2.15", use-cross: true }
           - { target: aarch64-apple-darwin        , os: macos-10.15  , nif: "2.15" }
           - { target: x86_64-apple-darwin         , os: macos-10.15  , nif: "2.15" }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04 , nif: "2.15" }
@@ -40,6 +42,7 @@ jobs:
           - { target: x86_64-pc-windows-msvc      , os: windows-2019 , nif: "2.15" }
           # NIF version 2.14
           - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04 , nif: "2.14", use-cross: true }
+          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04 , nif: "2.14", use-cross: true }
           - { target: aarch64-apple-darwin        , os: macos-10.15  , nif: "2.14" }
           - { target: x86_64-apple-darwin         , os: macos-10.15  , nif: "2.14" }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04 , nif: "2.14" }

--- a/lib/html5ever/precompiled.ex
+++ b/lib/html5ever/precompiled.ex
@@ -9,6 +9,7 @@ defmodule Html5ever.Precompiled do
     x86_64-unknown-linux-gnu
     x86_64-unknown-linux-musl
     arm-unknown-linux-gnueabihf
+    aarch64-unknown-linux-gnu
     x86_64-pc-windows-msvc
     x86_64-pc-windows-gnu
   )
@@ -171,7 +172,7 @@ defmodule Html5ever.Precompiled do
 
     # Fix vendor for Nerves
     vendor =
-      if arch == "arm" and vendor == "buildroot" do
+      if arch in ["arm", "aarch64"] and vendor == "buildroot" do
         "unknown"
       else
         vendor

--- a/test/html5ever/precompiled_test.exs
+++ b/test/html5ever/precompiled_test.exs
@@ -43,6 +43,14 @@ defmodule Html5ever.PrecompiledTest do
     assert {:ok, "nif-2.16-arm-unknown-linux-gnueabihf"} = Precompiled.target(config)
 
     config = %{
+      system_arch: %{arch: "aarch64", vendor: "buildroot", os: "linux", abi: "gnu"},
+      nif_version: "2.16",
+      os_type: {:unix, :linux}
+    }
+
+    assert {:ok, "nif-2.16-aarch64-unknown-linux-gnu"} = Precompiled.target(config)
+
+    config = %{
       system_arch: %{},
       word_size: 8,
       nif_version: "2.14",
@@ -58,7 +66,7 @@ defmodule Html5ever.PrecompiledTest do
     }
 
     error_message =
-      "precompiled NIF is not available for this target: \"i686-unknown-linux-gnu\".\nThe available targets are:\n - aarch64-apple-darwin\n - x86_64-apple-darwin\n - x86_64-unknown-linux-gnu\n - x86_64-unknown-linux-musl\n - arm-unknown-linux-gnueabihf\n - x86_64-pc-windows-msvc\n - x86_64-pc-windows-gnu"
+      "precompiled NIF is not available for this target: \"i686-unknown-linux-gnu\".\nThe available targets are:\n - aarch64-apple-darwin\n - x86_64-apple-darwin\n - x86_64-unknown-linux-gnu\n - x86_64-unknown-linux-musl\n - arm-unknown-linux-gnueabihf\n - aarch64-unknown-linux-gnu\n - x86_64-pc-windows-msvc\n - x86_64-pc-windows-gnu"
 
     assert {:error, ^error_message} = Precompiled.target(config)
   end


### PR DESCRIPTION
This is needed for the Raspberry Pi 4 that has a different architecture
from the other versions.