### PR TITLE
Performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Switch from thread pool to being a dirty NIF. This prevents the 
+resulting term from having to be sent between processes, and therefore 
+prevents an extra copy from having to be performed.
+- In the FlatSink implementation for the NIF, track children in a pool
+instead of allocating new vectors for every node. This significantly
+reduces allocator pressure while parsing, and improves performance.
+- When converting a parsed FlatSink into its term representation,
+use a common child node stack instead of allocating a new one for every
+node. This significantly reduces allocator pressure while creating terms, 
+and improves performance.
+
 ## [0.10.1] - 2021-11-24
 
 ### Fixed

--- a/lib/html5ever.ex
+++ b/lib/html5ever.ex
@@ -37,12 +37,8 @@ defmodule Html5ever do
        ]}
 
   """
-  def parse(html) when byte_size(html) > 500 do
-    parse_async(html)
-  end
-
   def parse(html) do
-    parse_sync(html)
+    parse_dirty(html)
   end
 
   @doc """
@@ -96,15 +92,11 @@ defmodule Html5ever do
        }}
 
   """
-  def flat_parse(html) when byte_size(html) > 500 do
-    flat_parse_async(html)
-  end
-
   def flat_parse(html) do
-    flat_parse_sync(html)
+    flat_parse_dirty(html)
   end
 
-  defp parse_sync(html) do
+  defp parse_dirty(html) do
     case Html5ever.Native.parse_sync(html) do
       {:html5ever_nif_result, :ok, result} ->
         {:ok, result}
@@ -114,32 +106,8 @@ defmodule Html5ever do
     end
   end
 
-  defp parse_async(html) do
-    :ok = Html5ever.Native.parse_async(html)
-
-    receive do
-      {:html5ever_nif_result, :ok, result} ->
-        {:ok, result}
-
-      {:html5ever_nif_result, :error, err} ->
-        {:error, err}
-    end
-  end
-
-  defp flat_parse_sync(html) do
+  defp flat_parse_dirty(html) do
     case Html5ever.Native.flat_parse_sync(html) do
-      {:html5ever_nif_result, :ok, result} ->
-        {:ok, result}
-
-      {:html5ever_nif_result, :error, err} ->
-        {:error, err}
-    end
-  end
-
-  defp flat_parse_async(html) do
-    :ok = Html5ever.Native.flat_parse_async(html)
-
-    receive do
       {:html5ever_nif_result, :ok, result} ->
         {:ok, result}
 

--- a/lib/html5ever/native.ex
+++ b/lib/html5ever/native.ex
@@ -39,9 +39,9 @@ defmodule Html5ever.Native do
   use Rustler, opts
 
   def parse_sync(_binary), do: err()
-  def parse_async(_binary), do: err()
+  def parse_dirty(_binary), do: err()
   def flat_parse_sync(_binary), do: err()
-  def flat_parse_async(_binary), do: err()
+  def flat_parse_dirty(_binary), do: err()
 
   defp err, do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/native/html5ever_nif/Cargo.toml
+++ b/native/html5ever_nif/Cargo.toml
@@ -18,3 +18,4 @@ markup5ever = "0.10"
 tendril = "0.4"
 lazy_static = "1.4"
 scoped-pool = "1.0"
+


### PR DESCRIPTION
This performs a few optimizations that improves performance up to 3x in the benchmarks I have performed.

The release-slow profile I added is pretty useless as it actually slightly decreases performance, we should probably not use it.

Performing PGO seems to squeeze out a bit more performance, but that's a more complex thing to set up, and is not included in this PR.

These are the main changes:
* switch from thread pool to dirty NIFs
* use arena instead of separate allocations for FlatSink childen
* use single child stack instead of separate stacks for FlatSink to recursive term conversion code
* add a release-slow profile

### Benchmarks
Below are the benchmarks from the `fast_html` bench suite.

We the only one we are still really slow on is `document-large.html`. This is a 7M HTML file. There might be more opportunities for improvement here, but I haven't looked too much into it.

```
Operating System: Linux
CPU Information: AMD Ryzen 9 5900HS with Radeon Graphics
Number of Available Cores: 16
Available memory: 30.78 GB
Elixir 1.13.0-dev
Erlang 24.0.2

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 0 ns
parallel: 1
inputs: document-large.html, document-medium.html, document-small.html, fragment-large.html, fragment-small.html
Estimated total run time: 35 s

Benchmarking html5ever nif with input document-large.html...
Benchmarking html5ever nif with input document-medium.html...
Benchmarking html5ever nif with input document-small.html...
Benchmarking html5ever nif with input fragment-large.html...
Benchmarking html5ever nif with input fragment-small.html...

##### With input document-large.html #####
Name                                                  ips        average  deviation         median         99th %
fast_html (2021-11-25--1-15-48-utc)                  8.73      114.52 ms     ±7.11%      113.58 ms      129.57 ms
new_html5ever nif (2021-11-25--1-15-48-utc)          3.55      281.90 ms     ±8.36%      280.29 ms      332.79 ms
html5ever nif                                        2.88      347.17 ms     ±4.69%      346.85 ms      379.65 ms

Comparison:
fast_html (2021-11-25--1-15-48-utc)                  8.73
new_html5ever nif (2021-11-25--1-15-48-utc)          3.55 - 2.46x slower +167.38 ms
html5ever nif                                        2.88 - 3.03x slower +232.65 ms

##### With input document-medium.html #####
Name                                                  ips        average  deviation         median         99th %
new_html5ever nif (2021-11-25--1-15-48-utc)        436.10        2.29 ms    ±28.59%        2.17 ms        6.16 ms
fast_html (2021-11-25--1-15-48-utc)                286.47        3.49 ms    ±25.21%        3.79 ms        4.77 ms
html5ever nif                                      145.18        6.89 ms    ±33.88%        6.92 ms       11.31 ms

Comparison:
new_html5ever nif (2021-11-25--1-15-48-utc)        436.10
fast_html (2021-11-25--1-15-48-utc)                286.47 - 1.52x slower +1.20 ms
html5ever nif                                      145.18 - 3.00x slower +4.59 ms

##### With input document-small.html #####
Name                                                  ips        average  deviation         median         99th %
new_html5ever nif (2021-11-25--1-15-48-utc)       2093.34        0.48 ms    ±11.94%        0.47 ms        0.66 ms
fast_html (2021-11-25--1-15-48-utc)                921.93        1.08 ms    ±18.36%        1.10 ms        1.44 ms
html5ever nif                                      877.96        1.14 ms    ±52.07%        0.91 ms        3.01 ms

Comparison:
new_html5ever nif (2021-11-25--1-15-48-utc)       2093.34
fast_html (2021-11-25--1-15-48-utc)                921.93 - 2.27x slower +0.61 ms
html5ever nif                                      877.96 - 2.38x slower +0.66 ms

##### With input fragment-large.html #####
Name                                                  ips        average  deviation         median         99th %
new_html5ever nif (2021-11-25--1-15-48-utc)       1257.22        0.80 ms     ±4.52%        0.79 ms        0.91 ms
fast_html (2021-11-25--1-15-48-utc)                620.16        1.61 ms    ±30.31%        1.76 ms        2.36 ms
html5ever nif                                      460.62        2.17 ms    ±55.46%        1.58 ms        5.11 ms

Comparison:
new_html5ever nif (2021-11-25--1-15-48-utc)       1257.22
fast_html (2021-11-25--1-15-48-utc)                620.16 - 2.03x slower +0.82 ms
html5ever nif                                      460.62 - 2.73x slower +1.38 ms

##### With input fragment-small.html #####
Name                                                  ips        average  deviation         median         99th %
new_html5ever nif (2021-11-25--1-15-48-utc)      139.91 K        7.15 μs   ±482.31%        6.22 μs       13.76 μs
html5ever nif                                     40.91 K       24.44 μs    ±77.56%       22.07 μs       68.58 μs
fast_html (2021-11-25--1-15-48-utc)               13.56 K       73.73 μs    ±54.69%       66.21 μs      199.11 μs

Comparison:
new_html5ever nif (2021-11-25--1-15-48-utc)      139.91 K
html5ever nif                                     40.91 K - 3.42x slower +17.29 μs
fast_html (2021-11-25--1-15-48-utc)               13.56 K - 10.32x slower +66.59 μs
```