### PR TITLE
Force NIF build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,9 @@ jobs:
       - run: mix deps.unlock --check-unused
         if: ${{ matrix.lint }}
 
-      - run: mix deps.compile
+      - run: HTML5EVER_BUILD=1 mix deps.compile
 
-      - run: mix compile --warnings-as-errors
+      - run: HTML5EVER_BUILD=1 mix compile --warnings-as-errors
         if: ${{ matrix.lint }}
 
-      - run: mix test
+      - run: HTML5EVER_BUILD=1 mix test


### PR DESCRIPTION
Currently the CI build will try to download the NIF when building and running tests.

We do not want this, CI builds should always do a complete build.