### PR TITLE
Fix override of target by env vars on macOS

### DIFF
--- a/test/html5ever/precompiled_test.exs
+++ b/test/html5ever/precompiled_test.exs
@@ -3,24 +3,30 @@ defmodule Html5ever.PrecompiledTest do
   alias Html5ever.Precompiled
 
   test "target/1" do
+    target_system = %{arch: "arm", vendor: "apple", os: "darwin20.3.0"}
+
     config = %{
-      system_arch: %{arch: "arm", vendor: "apple", os: "darwin20.3.0"},
+      target_system: target_system,
       nif_version: "2.16",
       os_type: {:unix, :darwin}
     }
 
     assert {:ok, "nif-2.16-aarch64-apple-darwin"} = Precompiled.target(config)
 
+    target_system = %{arch: "x86_64", vendor: "apple", os: "darwin20.3.0"}
+
     config = %{
-      config
-      | system_arch: %{arch: "x86_64", vendor: "apple", os: "darwin20.3.0"},
-        nif_version: "2.15"
+      target_system: target_system,
+      nif_version: "2.15",
+      os_type: {:unix, :darwin}
     }
 
     assert {:ok, "nif-2.15-x86_64-apple-darwin"} = Precompiled.target(config)
 
+    target_system = %{arch: "amd64", vendor: "pc", os: "linux", abi: "gnu"}
+
     config = %{
-      system_arch: %{arch: "amd64", vendor: "pc", os: "linux", abi: "gnu"},
+      target_system: target_system,
       nif_version: "2.14",
       os_type: {:unix, :linux}
     }
@@ -29,13 +35,13 @@ defmodule Html5ever.PrecompiledTest do
 
     config = %{
       config
-      | system_arch: %{arch: "x86_64", vendor: "unknown", os: "linux", abi: "gnu"}
+      | target_system: %{arch: "x86_64", vendor: "unknown", os: "linux", abi: "gnu"}
     }
 
     assert {:ok, "nif-2.14-x86_64-unknown-linux-gnu"} = Precompiled.target(config)
 
     config = %{
-      system_arch: %{arch: "arm", vendor: "buildroot", os: "linux", abi: "gnueabihf"},
+      target_system: %{arch: "arm", vendor: "unknown", os: "linux", abi: "gnueabihf"},
       nif_version: "2.16",
       os_type: {:unix, :linux}
     }
@@ -43,7 +49,7 @@ defmodule Html5ever.PrecompiledTest do
     assert {:ok, "nif-2.16-arm-unknown-linux-gnueabihf"} = Precompiled.target(config)
 
     config = %{
-      system_arch: %{arch: "aarch64", vendor: "buildroot", os: "linux", abi: "gnu"},
+      target_system: %{arch: "aarch64", vendor: "unknown", os: "linux", abi: "gnu"},
       nif_version: "2.16",
       os_type: {:unix, :linux}
     }
@@ -51,7 +57,15 @@ defmodule Html5ever.PrecompiledTest do
     assert {:ok, "nif-2.16-aarch64-unknown-linux-gnu"} = Precompiled.target(config)
 
     config = %{
-      system_arch: %{},
+      target_system: %{arch: "aarch64", vendor: "unknown", os: "linux", abi: "gnu"},
+      nif_version: "2.16",
+      os_type: {:unix, :darwin}
+    }
+
+    assert {:ok, "nif-2.16-aarch64-unknown-linux-gnu"} = Precompiled.target(config)
+
+    config = %{
+      target_system: %{},
       word_size: 8,
       nif_version: "2.14",
       os_type: {:win32, :nt}
@@ -60,7 +74,16 @@ defmodule Html5ever.PrecompiledTest do
     assert {:ok, "nif-2.14-x86_64-pc-windows-msvc"} = Precompiled.target(config)
 
     config = %{
-      system_arch: %{arch: "i686", vendor: "unknown", os: "linux", abi: "gnu"},
+      target_system: %{arch: "arm", vendor: "unknown", os: "linux", abi: "gnueabihf"},
+      word_size: 8,
+      nif_version: "2.14",
+      os_type: {:win32, :nt}
+    }
+
+    assert {:ok, "nif-2.14-arm-unknown-linux-gnueabihf"} = Precompiled.target(config)
+
+    config = %{
+      target_system: %{arch: "i686", vendor: "unknown", os: "linux", abi: "gnu"},
       nif_version: "2.14",
       os_type: {:unix, :linux}
     }
@@ -85,5 +108,44 @@ defmodule Html5ever.PrecompiledTest do
     assert Precompiled.find_compatible_nif_version("2.14", ["2.14"]) == {:ok, "2.14"}
     assert Precompiled.find_compatible_nif_version("2.17", ["2.14"]) == {:ok, "2.14"}
     assert Precompiled.find_compatible_nif_version("2.13", ["2.14"]) == :error
+  end
+
+  test "maybe_override_with_env_vars/2" do
+    target_system = %{
+      arch: "x86_64",
+      vendor: "apple",
+      os: "darwin20.3.0"
+    }
+
+    assert Precompiled.maybe_override_with_env_vars(target_system, fn _ -> nil end) ==
+             target_system
+
+    env_with_targets = fn
+      "TARGET_OS" -> "linux"
+      "TARGET_ARCH" -> "aarch64"
+      "TARGET_ABI" -> "gnu"
+      _ -> nil
+    end
+
+    assert Precompiled.maybe_override_with_env_vars(target_system, env_with_targets) == %{
+             arch: "aarch64",
+             vendor: "unknown",
+             os: "linux",
+             abi: "gnu"
+           }
+
+    env_with_targets = fn
+      "TARGET_OS" -> "freebsd"
+      "TARGET_ARCH" -> "arm"
+      "TARGET_ABI" -> "musl"
+      "TARGET_VENDOR" -> "ecorp"
+    end
+
+    assert Precompiled.maybe_override_with_env_vars(target_system, env_with_targets) == %{
+             arch: "arm",
+             vendor: "ecorp",
+             os: "freebsd",
+             abi: "musl"
+           }
   end
 end


### PR DESCRIPTION
This is related to the download of precompiled NIF.

We now check the OS from the target that may be overriden by the
TARGET_OS env var. Before that we were using `:os.type/1` as reference
for normalization, but this won´t work if the target is different from
the OS returned by that function.

This also fix the normalization of vendor. It sets to "unknown" if some
env var changed the target but didn't specify a vendor.