### PR TITLE
Add LTO flag for release build of NIF

### DIFF
--- a/native/html5ever_nif/.cargo/config
+++ b/native/html5ever_nif/.cargo/config
@@ -1,3 +1,6 @@
+[profile.release]
+lto = true
+
 [target.x86_64-apple-darwin]
 rustflags = [
   "-C", "link-arg=-undefined",


### PR DESCRIPTION
This is feature of LLVM that aims to improve the performance and reduce
the build size of generated artifacts.

See: https://llvm.org/docs/LinkTimeOptimization.html
And also: https://doc.rust-lang.org/cargo/reference/profiles.html#lto