### PR TITLE
Add integrity check before extracting precompiled NIFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ erl_crash.dump
 /priv/native
 
 /native/*/target
+
+# The checksum files for precompiled NIFs
+checksum-*.exs

--- a/lib/html5ever/native.ex
+++ b/lib/html5ever/native.ex
@@ -15,6 +15,7 @@ defmodule Html5ever.Native do
     else
       case Html5ever.Precompiled.download_or_reuse_nif_file(
              rustler_opts,
+             nif_module: __MODULE__,
              base_url: "#{github_url}/releases/download/v#{version}",
              version: version
            ) do

--- a/lib/html5ever/precompiled.ex
+++ b/lib/html5ever/precompiled.ex
@@ -15,6 +15,12 @@ defmodule Html5ever.Precompiled do
   )
   @available_nif_versions ~w(2.14 2.15 2.16)
 
+  def available_targets do
+    for target_triple <- @available_targets, nif_version <- @available_nif_versions do
+      "nif-#{nif_version}-#{target_triple}"
+    end
+  end
+
   @doc """
   Returns the target triple for download or compile and load.
 
@@ -222,6 +228,15 @@ defmodule Html5ever.Precompiled do
     with {:ok, target} <- target() do
       nif_name = rustler_opts[:crate] || name
       lib_name = "#{lib_prefix(target)}#{nif_name}-v#{version}-#{target}"
+
+      # We need to save some metadata for downloading.
+      # TODO: consider adding this to the module defining the NIF
+      # Application.put_env(name, __MODULE__,
+      #   nif_name: nif_name,
+      #   lib_name: lib_name,
+      #   version: version,
+      #   target: target
+      # )
 
       file_name = lib_name_with_ext(target, lib_name)
       cached_tar_gz = Path.join(cache_dir, "#{file_name}.tar.gz")

--- a/lib/html5ever/precompiled.ex
+++ b/lib/html5ever/precompiled.ex
@@ -310,9 +310,7 @@ defmodule Html5ever.Precompiled do
         File.exists?(cached_tar_gz) ->
           # Remove existing NIF file so we don't have processes using it.
           # See: https://github.com/rusterlium/rustler/blob/46494d261cbedd3c798f584459e42ab7ee6ea1f4/rustler_mix/lib/rustler/compiler.ex#L134
-          if File.exists?(lib_file) do
-            File.rm!(lib_file)
-          end
+          File.rm(lib_file)
 
           with :ok <- check_file_integrity(cached_tar_gz, nif_module, name),
                :ok <- :erl_tar.extract(cached_tar_gz, [:compressed, cwd: Path.dirname(lib_file)]) do

--- a/lib/mix/tasks/rustler.download.ex
+++ b/lib/mix/tasks/rustler.download.ex
@@ -24,11 +24,11 @@ defmodule Mix.Tasks.Rustler.Download do
         ["--all"] ->
           Precompiled.available_nif_urls(module_name)
 
-        ["--only-target"] ->
+        ["--only-local"] ->
           [Precompiled.current_target_nif_url(module_name)]
 
         [] ->
-          raise "you need to specify either \"--all\" or \"--only-target\" flags"
+          raise "you need to specify either \"--all\" or \"--only-local\" flags"
       end
 
     result = Precompiled.download_nif_artifacts_with_checksums!(urls)
@@ -37,6 +37,6 @@ defmodule Mix.Tasks.Rustler.Download do
 
   @impl true
   def run([]) do
-    raise "the module name and a flag is expected. Use \"--all\" or \"--only-target\" flags"
+    raise "the module name and a flag is expected. Use \"--all\" or \"--only-local\" flags"
   end
 end

--- a/lib/mix/tasks/rustler.download.ex
+++ b/lib/mix/tasks/rustler.download.ex
@@ -4,9 +4,13 @@ defmodule Mix.Tasks.Rustler.Download do
   @moduledoc """
   This is responsible for downloading the precompiled NIFs for a given module.
 
-  It will also save the checksum file in the proper location in case it is not
-  present. This is important because we need to calculate the checksum before
-  extracting the NIF to the proper location.
+  This task must only be used by Rustler's package creators who want to ship
+  precompiled NIFs. The goal is to download precompiled packages and
+  generate a checksum to check-in alongside the Hex repository. This is done
+  by passing the `--all` flag.
+
+  You can also use the `--only-local` flag to download only the precompiled
+  package for use during development.
   """
 
   use Mix.Task

--- a/lib/mix/tasks/rustler.download.ex
+++ b/lib/mix/tasks/rustler.download.ex
@@ -1,0 +1,10 @@
+defmodule Mix.Tasks.Rustler.Download do
+  @shortdoc "Download precompiled NIFs and build checksums"
+
+  use Mix.Task
+
+  @impl true
+  def run(_) do
+    IO.puts(inspect(Html5ever.Precompiled.available_targets()))
+  end
+end

--- a/lib/mix/tasks/rustler.download.ex
+++ b/lib/mix/tasks/rustler.download.ex
@@ -3,8 +3,18 @@ defmodule Mix.Tasks.Rustler.Download do
 
   use Mix.Task
 
+  # mix rustler.download Html5Ever --all 
+  # or
+  # mix rustler.download Html5Ever
+
   @impl true
   def run(_) do
-    IO.puts(inspect(Html5ever.Precompiled.available_targets()))
+    urls = Html5ever.Precompiled.available_nif_urls("Html5ever.Native")
+    IO.puts(inspect(urls))
+
+    result = Html5ever.Precompiled.download_nif_artifacts_with_checksums(urls)
+
+    IO.inspect(result, label: "checksums")
+    # TODO: save result in "priv/native" of the otp app (get from metadata)
   end
 end

--- a/lib/mix/tasks/rustler.download.ex
+++ b/lib/mix/tasks/rustler.download.ex
@@ -21,13 +21,15 @@ defmodule Mix.Tasks.Rustler.Download do
 
   @impl true
   def run([module_name | maybe_flags]) do
+    module = String.to_atom("Elixir.#{module_name}")
+
     urls =
       cond do
         "--all" in maybe_flags ->
-          Precompiled.available_nif_urls(module_name)
+          Precompiled.available_nif_urls(module)
 
         "--only-local" in maybe_flags ->
-          [Precompiled.current_target_nif_url(module_name)]
+          [Precompiled.current_target_nif_url(module)]
 
         true ->
           raise "you need to specify either \"--all\" or \"--only-local\" flags"
@@ -45,7 +47,7 @@ defmodule Mix.Tasks.Rustler.Download do
       |> IO.puts()
     end
 
-    Precompiled.write_checksum!(module_name, result)
+    Precompiled.write_checksum!(module, result)
   end
 
   @impl true

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Html5ever.Mixfile do
       files: [
         "lib",
         "native",
-        "priv/native/checksum-*.exs",
+        "checksum-*.exs",
         "mix.exs",
         "README.md",
         "CHANGELOG.md",

--- a/mix.exs
+++ b/mix.exs
@@ -46,6 +46,7 @@ defmodule Html5ever.Mixfile do
       files: [
         "lib",
         "native",
+        "priv/native/checksum-*.exs",
         "mix.exs",
         "README.md",
         "CHANGELOG.md",

--- a/test/html5ever/precompiled_test.exs
+++ b/test/html5ever/precompiled_test.exs
@@ -189,8 +189,11 @@ defmodule Html5ever.PrecompiledTest do
 
     wrong_file_path = Path.join(tmp_dir, "i-dont-exist/poem.txt")
 
-    assert {:error,
-            "cannot read the file for checksum comparison: \"/home/philip/sandbox/html5ever_elixir/tmp/Html5ever.PrecompiledTest/test-check_integrity_from_map-3/i-dont-exist/poem.txt\". Reason: :enoent"} =
+    assert {:error, message} =
              Precompiled.check_integrity_from_map(checksum_map, wrong_file_path, MyModule)
+
+    assert message =~ "cannot read the file for checksum comparison: "
+    assert message =~ wrong_file_path
+    assert message =~ "Reason: :enoent"
   end
 end

--- a/test/html5ever/precompiled_test.exs
+++ b/test/html5ever/precompiled_test.exs
@@ -148,4 +148,43 @@ defmodule Html5ever.PrecompiledTest do
              abi: "musl"
            }
   end
+
+  @tag :tmp_dir
+  test "check_integrity_from_map/3", %{tmp_dir: tmp_dir} do
+    content = """
+    Roses are red
+    Violets are blue
+    """
+
+    file_path = Path.join(tmp_dir, "poem.txt")
+    :ok = File.write(file_path, content)
+
+    # the checksum is calculated with `:crypto.hash(:sha256, content) |> Base.encode16(case: :lower)`
+    checksum_map = %{
+      "poem.txt" => "sha256:fe16da553f29a704ad4c78624bc9354b8e4df6e4de8edb5b0f8d9f9090501911"
+    }
+
+    assert :ok = Precompiled.check_integrity_from_map(checksum_map, file_path, "MyModule")
+
+    assert {:error,
+            "the precompiled NIF file does not exist in the checksum file. Please consider run: `mix rustler.download MyModule --only-local` to generate the checksum file."} =
+             Precompiled.check_integrity_from_map(checksum_map, "idontexist", "MyModule")
+
+    not_supported_checksum_map = %{
+      "poem.txt" => "md5:fe16da553f29a704ad4c78624bc9354b8e4df6e4de8edb5b0f8d9f9090501911"
+    }
+
+    assert {:error,
+            "checksum algorithm is not supported: :md5. The supported ones are:\n - sha256"} =
+             Precompiled.check_integrity_from_map(
+               not_supported_checksum_map,
+               file_path,
+               "MyModule"
+             )
+
+    :ok = File.write(file_path, "let's change the content of the file")
+
+    assert {:error, "the integrity check failed because the checksum of files does not match"} =
+             Precompiled.check_integrity_from_map(checksum_map, file_path, "MyModule")
+  end
 end

--- a/test/html5ever/precompiled_test.exs
+++ b/test/html5ever/precompiled_test.exs
@@ -164,11 +164,11 @@ defmodule Html5ever.PrecompiledTest do
       "poem.txt" => "sha256:fe16da553f29a704ad4c78624bc9354b8e4df6e4de8edb5b0f8d9f9090501911"
     }
 
-    assert :ok = Precompiled.check_integrity_from_map(checksum_map, file_path, "MyModule")
+    assert :ok = Precompiled.check_integrity_from_map(checksum_map, file_path, MyModule)
 
     assert {:error,
             "the precompiled NIF file does not exist in the checksum file. Please consider run: `mix rustler.download MyModule --only-local` to generate the checksum file."} =
-             Precompiled.check_integrity_from_map(checksum_map, "idontexist", "MyModule")
+             Precompiled.check_integrity_from_map(checksum_map, "idontexist", MyModule)
 
     not_supported_checksum_map = %{
       "poem.txt" => "md5:fe16da553f29a704ad4c78624bc9354b8e4df6e4de8edb5b0f8d9f9090501911"
@@ -179,12 +179,12 @@ defmodule Html5ever.PrecompiledTest do
              Precompiled.check_integrity_from_map(
                not_supported_checksum_map,
                file_path,
-               "MyModule"
+               MyModule
              )
 
     :ok = File.write(file_path, "let's change the content of the file")
 
     assert {:error, "the integrity check failed because the checksum of files does not match"} =
-             Precompiled.check_integrity_from_map(checksum_map, file_path, "MyModule")
+             Precompiled.check_integrity_from_map(checksum_map, file_path, MyModule)
   end
 end

--- a/test/html5ever/precompiled_test.exs
+++ b/test/html5ever/precompiled_test.exs
@@ -186,5 +186,11 @@ defmodule Html5ever.PrecompiledTest do
 
     assert {:error, "the integrity check failed because the checksum of files does not match"} =
              Precompiled.check_integrity_from_map(checksum_map, file_path, MyModule)
+
+    wrong_file_path = Path.join(tmp_dir, "i-dont-exist/poem.txt")
+
+    assert {:error,
+            "cannot read the file for checksum comparison: \"/home/philip/sandbox/html5ever_elixir/tmp/Html5ever.PrecompiledTest/test-check_integrity_from_map-3/i-dont-exist/poem.txt\". Reason: :enoent"} =
+             Precompiled.check_integrity_from_map(checksum_map, wrong_file_path, MyModule)
   end
 end


### PR DESCRIPTION
This change is necessary to avoid supply chain attacks.

The idea is to protect the user in case the place we publish the artifacts is compromised (in our case, GitHub CDN).
This works by reading a checksum file for the given NIF before extracting the lib file.

In order for this to work, the maintainers of the lib MUST generate the checksum file right before publishing a new version to Hex.
The file won't be versioned in this repository, but will be present in our package.