### PR TITLE
Add Cross.toml in order to pass the NIF version to cross

### DIFF
--- a/native/html5ever_nif/Cross.toml
+++ b/native/html5ever_nif/Cross.toml
@@ -1,0 +1,4 @@
+[build.env]
+passthrough = [
+  "RUSTLER_NIF_VERSION"
+]


### PR DESCRIPTION
This is important because `cross` don't have access by default to the
env vars in the system.

This is related to https://github.com/philss/rustler_precompiled/issues/23