### PR TITLE
Add parse functions that return attributes as maps

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,0 +1,38 @@
+name: Rust CI
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "native/**"
+  pull_request:
+    paths:
+      - "native/**"
+  workflow_dispatch:
+
+jobs:
+  lint-rust:
+    name: Lint Rust
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        manifest:
+          - native/html5ever_nif/Cargo.toml
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            native/html5ever_nif
+
+      - name: run rustfmt
+        run: cargo fmt --manifest-path=${{ matrix.manifest }} --all -- --check
+
+      - name: run clippy
+        run: cargo clippy --manifest-path=${{ matrix.manifest }} -- -Dwarnings

--- a/lib/html5ever.ex
+++ b/lib/html5ever.ex
@@ -37,8 +37,30 @@ defmodule Html5ever do
        ]}
 
   """
-  def parse(html) do
-    parse_dirty(html)
+  def parse(html) when is_binary(html) do
+    Html5ever.Native.parse(html, false)
+  end
+
+  @doc """
+  Same as `parse/1`, but with attributes as maps.
+
+  This is going to remove duplicated attributes, keeping the ones
+  that appear first.
+
+  ## Example
+
+      iex> Html5ever.parse_with_attributes_as_maps(
+      ...>   "<!doctype html><html><body><h1 class=title>Hello world</h1></body></html>"
+      ...> )
+      {:ok,
+       [
+         {:doctype, "html", "", ""},
+         {"html", %{}, [{"head", %{}, []}, {"body", %{}, [{"h1", %{"class" => "title"}, ["Hello world"]}]}]}
+       ]}
+
+  """
+  def parse_with_attributes_as_maps(html) when is_binary(html) do
+    Html5ever.Native.parse(html, true)
   end
 
   @doc """
@@ -93,26 +115,16 @@ defmodule Html5ever do
 
   """
   def flat_parse(html) do
-    flat_parse_dirty(html)
+    Html5ever.Native.flat_parse(html, false)
   end
 
-  defp parse_dirty(html) do
-    case Html5ever.Native.parse_sync(html) do
-      {:html5ever_nif_result, :ok, result} ->
-        {:ok, result}
+  @doc """
+  Same as `flat_parse/1`, but with attributes as maps.
 
-      {:html5ever_nif_result, :error, err} ->
-        {:error, err}
-    end
-  end
-
-  defp flat_parse_dirty(html) do
-    case Html5ever.Native.flat_parse_sync(html) do
-      {:html5ever_nif_result, :ok, result} ->
-        {:ok, result}
-
-      {:html5ever_nif_result, :error, err} ->
-        {:error, err}
-    end
+  This is going to remove duplicated attributes, keeping the ones
+  that appear first.
+  """
+  def flat_parse_with_attributes_as_maps(html) when is_binary(html) do
+    Html5ever.Native.flat_parse(html, true)
   end
 end

--- a/lib/html5ever.ex
+++ b/lib/html5ever.ex
@@ -114,7 +114,7 @@ defmodule Html5ever do
        }}
 
   """
-  def flat_parse(html) do
+  def flat_parse(html) when is_binary(html) do
     Html5ever.Native.flat_parse(html, false)
   end
 

--- a/lib/html5ever/native.ex
+++ b/lib/html5ever/native.ex
@@ -19,10 +19,8 @@ defmodule Html5ever.Native do
       System.get_env("HTML5EVER_BUILD") in ["1", "true"] or env_config[:build_from_source],
     version: version
 
-  def parse_sync(_binary), do: err()
-  def parse_dirty(_binary), do: err()
-  def flat_parse_sync(_binary), do: err()
-  def flat_parse_dirty(_binary), do: err()
+  def parse(_binary, _attrs_as_maps), do: err()
+  def flat_parse(_binary, _attrs_as_maps), do: err()
 
   defp err, do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/native/html5ever_nif/Cargo.lock
+++ b/native/html5ever_nif/Cargo.lock
@@ -79,6 +79,7 @@ dependencies = [
  "markup5ever",
  "rustler",
  "tendril",
+ "thiserror",
 ]
 
 [[package]]
@@ -411,6 +412,26 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.16",
 ]
 
 [[package]]

--- a/native/html5ever_nif/Cargo.toml
+++ b/native/html5ever_nif/Cargo.toml
@@ -17,3 +17,5 @@ markup5ever = "0.11"
 
 tendril = "0.4"
 lazy_static = "1.4"
+
+thiserror = "1"

--- a/native/html5ever_nif/src/flat_dom.rs
+++ b/native/html5ever_nif/src/flat_dom.rs
@@ -377,7 +377,7 @@ impl Encoder for NodeHandle {
     }
 }
 
-fn insert_error(_err: rustler::error::Error) -> Html5everExError {
+fn to_custom_error(_err: rustler::error::Error) -> Html5everExError {
     Html5everExError::MapEntry
 }
 
@@ -398,7 +398,7 @@ fn encode_node<'a>(
         ),
     ];
 
-    let mut map = Term::map_from_pairs(env, &pairs).map_err(insert_error)?;
+    let mut map = Term::map_from_pairs(env, &pairs).map_err(to_custom_error)?;
 
     match node.data {
         NodeData::Document => map
@@ -406,7 +406,7 @@ fn encode_node<'a>(
                 self::atoms::type_().encode(env),
                 self::atoms::document().encode(env),
             )
-            .map_err(insert_error),
+            .map_err(to_custom_error),
         NodeData::Element {
             ref attrs,
             ref name,
@@ -432,7 +432,7 @@ fn encode_node<'a>(
             ];
 
             for (key, value) in pairs {
-                map = map.map_put(key, value).map_err(insert_error)?;
+                map = map.map_put(key, value).map_err(to_custom_error)?;
             }
 
             Ok(map)
@@ -442,29 +442,29 @@ fn encode_node<'a>(
                 self::atoms::type_().encode(env),
                 self::atoms::text().encode(env),
             )
-            .map_err(insert_error)?
+            .map_err(to_custom_error)?
             .map_put(
                 self::atoms::contents().encode(env),
                 StrTendrilWrapper(contents).encode(env),
             )
-            .map_err(insert_error),
+            .map_err(to_custom_error),
         NodeData::DocType { .. } => map
             .map_put(
                 self::atoms::type_().encode(env),
                 self::atoms::doctype().encode(env),
             )
-            .map_err(insert_error),
+            .map_err(to_custom_error),
         NodeData::Comment { ref contents } => map
             .map_put(
                 self::atoms::type_().encode(env),
                 self::atoms::comment().encode(env),
             )
-            .map_err(insert_error)?
+            .map_err(to_custom_error)?
             .map_put(
                 self::atoms::contents().encode(env),
                 StrTendrilWrapper(contents).encode(env),
             )
-            .map_err(insert_error),
+            .map_err(to_custom_error),
         _ => unimplemented!(),
     }
 }
@@ -504,14 +504,14 @@ pub fn flat_sink_to_flat_term<'a>(
                 node.id.encode(env),
                 encode_node(node, env, &sink.pool, attributes_as_maps)?,
             )
-            .map_err(insert_error)?;
+            .map_err(to_custom_error)?;
     }
 
     ::rustler::types::map::map_new(env)
         .map_put(self::atoms::nodes().encode(env), nodes_map)
-        .map_err(insert_error)?
+        .map_err(to_custom_error)?
         .map_put(self::atoms::root().encode(env), sink.root.encode(env))
-        .map_err(insert_error)
+        .map_err(to_custom_error)
 }
 
 struct RecState {

--- a/native/html5ever_nif/src/flat_dom.rs
+++ b/native/html5ever_nif/src/flat_dom.rs
@@ -388,12 +388,12 @@ fn encode_node<'a>(
     attributes_as_maps: bool,
 ) -> Result<Term<'a>, Html5everExError> {
     let pairs: Vec<(Term, Term)> = vec![
-        (self::atoms::id().encode(env), node.id.encode(env)),
+        (atoms::id().encode(env), node.id.encode(env)),
         (
-            self::atoms::parent().encode(env),
+            atoms::parent().encode(env),
             match node.parent {
                 Some(handle) => handle.encode(env),
-                None => self::atoms::nil().encode(env),
+                None => atoms::nil().encode(env),
             },
         ),
     ];
@@ -402,10 +402,7 @@ fn encode_node<'a>(
 
     match node.data {
         NodeData::Document => map
-            .map_put(
-                self::atoms::type_().encode(env),
-                self::atoms::document().encode(env),
-            )
+            .map_put(atoms::type_().encode(env), atoms::document().encode(env))
             .map_err(to_custom_error),
         NodeData::Element {
             ref attrs,
@@ -413,20 +410,14 @@ fn encode_node<'a>(
             ..
         } => {
             let pairs: Vec<(Term, Term)> = vec![
+                (atoms::type_().encode(env), atoms::element().encode(env)),
                 (
-                    self::atoms::type_().encode(env),
-                    self::atoms::element().encode(env),
-                ),
-                (
-                    self::atoms::children().encode(env),
+                    atoms::children().encode(env),
                     node.children.as_slice(pool).encode(env),
                 ),
+                (atoms::name().encode(env), QualNameWrapper(name).encode(env)),
                 (
-                    self::atoms::name().encode(env),
-                    QualNameWrapper(name).encode(env),
-                ),
-                (
-                    self::atoms::attrs().encode(env),
+                    atoms::attrs().encode(env),
                     attributes_to_term(env, attrs, attributes_as_maps),
                 ),
             ];
@@ -438,30 +429,21 @@ fn encode_node<'a>(
             Ok(map)
         }
         NodeData::Text { ref contents } => map
-            .map_put(
-                self::atoms::type_().encode(env),
-                self::atoms::text().encode(env),
-            )
+            .map_put(atoms::type_().encode(env), atoms::text().encode(env))
             .map_err(to_custom_error)?
             .map_put(
-                self::atoms::contents().encode(env),
+                atoms::contents().encode(env),
                 StrTendrilWrapper(contents).encode(env),
             )
             .map_err(to_custom_error),
         NodeData::DocType { .. } => map
-            .map_put(
-                self::atoms::type_().encode(env),
-                self::atoms::doctype().encode(env),
-            )
+            .map_put(atoms::type_().encode(env), atoms::doctype().encode(env))
             .map_err(to_custom_error),
         NodeData::Comment { ref contents } => map
-            .map_put(
-                self::atoms::type_().encode(env),
-                self::atoms::comment().encode(env),
-            )
+            .map_put(atoms::type_().encode(env), atoms::comment().encode(env))
             .map_err(to_custom_error)?
             .map_put(
-                self::atoms::contents().encode(env),
+                atoms::contents().encode(env),
                 StrTendrilWrapper(contents).encode(env),
             )
             .map_err(to_custom_error),
@@ -508,9 +490,9 @@ pub fn flat_sink_to_flat_term<'a>(
     }
 
     ::rustler::types::map::map_new(env)
-        .map_put(self::atoms::nodes().encode(env), nodes_map)
+        .map_put(atoms::nodes().encode(env), nodes_map)
         .map_err(to_custom_error)?
-        .map_put(self::atoms::root().encode(env), sink.root.encode(env))
+        .map_put(atoms::root().encode(env), sink.root.encode(env))
         .map_err(to_custom_error)
 }
 
@@ -576,7 +558,7 @@ pub fn flat_sink_to_rec_term<'a>(
                     assert!(child_stack.is_empty());
 
                     term = (
-                        self::atoms::doctype(),
+                        atoms::doctype(),
                         StrTendrilWrapper(name),
                         StrTendrilWrapper(public_id),
                         StrTendrilWrapper(system_id),

--- a/native/html5ever_nif/src/lib.rs
+++ b/native/html5ever_nif/src/lib.rs
@@ -19,13 +19,14 @@ mod atoms {
 pub enum Html5everExError {
     #[error("cannot transform bytes from binary to a valid UTF8 string")]
     BytesToUtf8(#[from] std::str::Utf8Error),
+
+    #[error("cannot insert entry in a map")]
+    MapEntry,
 }
 
 impl rustler::Encoder for Html5everExError {
     fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
-        match self {
-            Html5everExError::BytesToUtf8(ref message) => message.to_string().encode(env),
-        }
+        format!("{self}").encode(env)
     }
 }
 
@@ -37,11 +38,7 @@ fn parse<'a>(
 ) -> Result<Term<'a>, Html5everExError> {
     let flat_sink = build_flat_sink(binary.as_slice())?;
 
-    Ok(flat_dom::flat_sink_to_rec_term(
-        env,
-        &flat_sink,
-        attributes_as_maps,
-    ))
+    flat_dom::flat_sink_to_rec_term(env, &flat_sink, attributes_as_maps)
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
@@ -52,11 +49,7 @@ fn flat_parse<'a>(
 ) -> Result<Term<'a>, Html5everExError> {
     let flat_sink = build_flat_sink(binary.as_slice())?;
 
-    Ok(flat_dom::flat_sink_to_flat_term(
-        env,
-        &flat_sink,
-        attributes_as_maps,
-    ))
+    flat_dom::flat_sink_to_flat_term(env, &flat_sink, attributes_as_maps)
 }
 
 fn build_flat_sink(bin_slice: &[u8]) -> Result<FlatSink, Html5everExError> {

--- a/native/html5ever_nif/src/lib.rs
+++ b/native/html5ever_nif/src/lib.rs
@@ -8,13 +8,6 @@ use thiserror::Error;
 mod common;
 mod flat_dom;
 
-mod atoms {
-    rustler::atoms! {
-        doctype,
-        comment,
-    }
-}
-
 #[derive(Error, Debug)]
 pub enum Html5everExError {
     #[error("cannot transform bytes from binary to a valid UTF8 string")]

--- a/native/html5ever_nif/src/lib.rs
+++ b/native/html5ever_nif/src/lib.rs
@@ -1,98 +1,76 @@
+use flat_dom::FlatSink;
 use rustler::types::binary::Binary;
-use rustler::{Decoder, Encoder, Env, Error, NifResult, Term};
+use rustler::{Env, Term};
 
-//use html5ever::rcdom::RcDom;
 use tendril::TendrilSink;
+use thiserror::Error;
 
 mod common;
 mod flat_dom;
 
 mod atoms {
     rustler::atoms! {
-        html5ever_nif_result,
-
-        ok,
-        error,
-        nif_panic,
-
         doctype,
         comment,
-
-        none,
-        some,
-        all,
     }
 }
 
-#[derive(PartialEq, Eq)]
-enum ErrorLevel {
-    None,
-    Some,
-    All,
+#[derive(Error, Debug)]
+pub enum Html5everExError {
+    #[error("cannot transform bytes from binary to a valid UTF8 string")]
+    BytesToUtf8(#[from] std::str::Utf8Error),
 }
-impl<'a> Decoder<'a> for ErrorLevel {
-    fn decode(term: Term<'a>) -> NifResult<ErrorLevel> {
-        if atoms::none() == term {
-            Ok(ErrorLevel::None)
-        } else if atoms::some() == term {
-            Ok(ErrorLevel::Some)
-        } else if atoms::all() == term {
-            Ok(ErrorLevel::All)
-        } else {
-            Err(Error::BadArg)
+
+impl rustler::Encoder for Html5everExError {
+    fn encode<'a>(&self, env: Env<'a>) -> Term<'a> {
+        match self {
+            Html5everExError::BytesToUtf8(ref message) => message.to_string().encode(env),
         }
     }
 }
 
-#[rustler::nif]
-fn parse_sync<'a>(env: Env<'a>, binary: Binary) -> Term<'a> {
-    parse(env, binary)
+#[rustler::nif(schedule = "DirtyCpu")]
+fn parse<'a>(
+    env: Env<'a>,
+    binary: Binary,
+    attributes_as_maps: bool,
+) -> Result<Term<'a>, Html5everExError> {
+    let flat_sink = build_flat_sink(binary.as_slice())?;
+
+    Ok(flat_dom::flat_sink_to_rec_term(
+        env,
+        &flat_sink,
+        attributes_as_maps,
+    ))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-fn parse_dirty<'a>(env: Env<'a>, binary: Binary) -> Term<'a> {
-    parse(env, binary)
+fn flat_parse<'a>(
+    env: Env<'a>,
+    binary: Binary,
+    attributes_as_maps: bool,
+) -> Result<Term<'a>, Html5everExError> {
+    let flat_sink = build_flat_sink(binary.as_slice())?;
+
+    Ok(flat_dom::flat_sink_to_flat_term(
+        env,
+        &flat_sink,
+        attributes_as_maps,
+    ))
 }
 
-fn parse<'a>(env: Env<'a>, binary: Binary) -> Term<'a> {
+fn build_flat_sink(bin_slice: &[u8]) -> Result<FlatSink, Html5everExError> {
+    let utf8 = std::str::from_utf8(bin_slice)?;
+
     let sink = flat_dom::FlatSink::new();
-
-    let utf = std::str::from_utf8(binary.as_slice()).unwrap();
-
     let parser = html5ever::parse_document(sink, Default::default());
-    let result = parser.one(utf);
 
-    let result_term = flat_dom::flat_sink_to_rec_term(env, &result);
-
-    (atoms::html5ever_nif_result(), atoms::ok(), result_term).encode(env)
-}
-
-#[rustler::nif]
-fn flat_parse_sync<'a>(env: Env<'a>, binary: Binary) -> Term<'a> {
-    flat_parse(env, binary)
-}
-
-#[rustler::nif(schedule = "DirtyCpu")]
-fn flat_parse_dirty<'a>(env: Env<'a>, binary: Binary) -> Term<'a> {
-    flat_parse(env, binary)
-}
-
-fn flat_parse<'a>(env: Env<'a>, binary: Binary) -> Term<'a> {
-    let sink = flat_dom::FlatSink::new();
-
-    let utf = std::str::from_utf8(binary.as_slice()).unwrap();
-
-    let parser = html5ever::parse_document(sink, Default::default());
-    let result = parser.one(utf);
-
-    let result_term = flat_dom::flat_sink_to_flat_term(env, &result);
-
-    (atoms::html5ever_nif_result(), atoms::ok(), result_term).encode(env)
+    Ok(parser.one(utf8))
 }
 
 rustler::init!(
     "Elixir.Html5ever.Native",
-    [parse_sync, parse_dirty, flat_parse_sync, flat_parse_dirty],
+    [parse, flat_parse],
     load = on_load
 );
 

--- a/test/html5ever_test.exs
+++ b/test/html5ever_test.exs
@@ -9,8 +9,17 @@ defmodule Html5everTest do
 
   test "parse basic html" do
     html = "<html><head></head><body></body></html>"
-    ret = {:ok, [{"html", [], [{"head", [], []}, {"body", [], []}]}]}
-    assert Html5ever.parse(html) == ret
+
+    assert Html5ever.parse(html) == {:ok, [{"html", [], [{"head", [], []}, {"body", [], []}]}]}
+  end
+
+  test "does not parse with not valid UTF8 binary" do
+    invalid =
+      <<98, 29, 104, 122, 46, 145, 14, 37, 122, 155, 227, 121, 49, 120, 108, 209, 155, 113, 229,
+        98, 90, 181, 146>>
+
+    assert Html5ever.parse(invalid) ==
+             {:error, "cannot transform bytes from binary to a valid UTF8 string"}
   end
 
   test "flat parse basic html" do
@@ -36,6 +45,15 @@ defmodule Html5everTest do
        }}
 
     assert Html5ever.flat_parse(html) == ret
+  end
+
+  test "does not flat parse with not valid UTF8 binary" do
+    invalid =
+      <<98, 29, 104, 122, 46, 145, 14, 37, 122, 155, 227, 121, 49, 120, 108, 209, 155, 113, 229,
+        98, 90, 181, 146>>
+
+    assert Html5ever.flat_parse(invalid) ==
+             {:error, "cannot transform bytes from binary to a valid UTF8 string"}
   end
 
   test "flat parse basic html with attributes as maps" do

--- a/test/html5ever_test.exs
+++ b/test/html5ever_test.exs
@@ -3,8 +3,8 @@ defmodule Html5everTest do
   doctest Html5ever
 
   def read_html(name) do
-    dir = to_string(:code.priv_dir(:html5ever)) <> "/test_data/"
-    File.read!(dir <> name)
+    path = Path.join([:code.priv_dir(:html5ever), "test_data", name])
+    File.read!(path)
   end
 
   test "parse basic html" do
@@ -36,6 +36,32 @@ defmodule Html5everTest do
        }}
 
     assert Html5ever.flat_parse(html) == ret
+  end
+
+  test "flat parse basic html with attributes as maps" do
+    # Duplicated attribute is removed.
+    html = "<html><head></head><body test=\"woo\" class=\"content\" test=\"baz\"></body></html>"
+
+    ret =
+      {:ok,
+       %{
+         nodes: %{
+           0 => %{id: 0, parent: nil, type: :document},
+           1 => %{children: [2, 3], id: 1, parent: 0, type: :element, attrs: %{}, name: "html"},
+           2 => %{children: [], id: 2, parent: 1, type: :element, attrs: %{}, name: "head"},
+           3 => %{
+             children: [],
+             id: 3,
+             parent: 1,
+             type: :element,
+             attrs: %{"test" => "woo", "class" => "content"},
+             name: "body"
+           }
+         },
+         root: 0
+       }}
+
+    assert Html5ever.flat_parse_with_attributes_as_maps(html) == ret
   end
 
   test "parse example.com html" do
@@ -133,6 +159,86 @@ defmodule Html5everTest do
                           "\n",
                           "        ",
                           {"img", [{"src", "file.jpg"}], []},
+                          "\n",
+                          "      "
+                        ]},
+                       "\n",
+                       "    "
+                     ]},
+                    "\n",
+                    "  ",
+                    "\n",
+                    "\n"
+                  ]}
+               ]}
+            ]} = parsed
+  end
+
+  test "reasonably deep html with attributes as maps" do
+    html = """
+    <!doctype html>
+    <html>
+      <head>
+        <title>Test</title>
+      </head>
+      <body>
+        <div class="content">
+          <span>
+            <div>
+              <span>
+                <small>
+                very deep content
+                </small>
+              </span>
+            </div>
+            <img src="file.jpg" />
+          </span>
+        </div>
+      </body>
+    </html>
+    """
+
+    parsed = Html5ever.parse_with_attributes_as_maps(html)
+
+    assert {:ok,
+            [
+              {:doctype, "html", "", ""},
+              {"html", %{},
+               [
+                 {"head", %{}, ["\n", "    ", {"title", %{}, ["Test"]}, "\n", "  "]},
+                 "\n",
+                 "  ",
+                 {"body", %{},
+                  [
+                    "\n",
+                    "    ",
+                    {"div", %{"class" => "content"},
+                     [
+                       "\n",
+                       "      ",
+                       {"span", %{},
+                        [
+                          "\n",
+                          "        ",
+                          {"div", %{},
+                           [
+                             "\n",
+                             "          ",
+                             {"span", %{},
+                              [
+                                "\n",
+                                "            ",
+                                {"small", %{},
+                                 ["\n", "            very deep content", "\n", "            "]},
+                                "\n",
+                                "          "
+                              ]},
+                             "\n",
+                             "        "
+                           ]},
+                          "\n",
+                          "        ",
+                          {"img", %{"src" => "file.jpg"}, []},
                           "\n",
                           "      "
                         ]},


### PR DESCRIPTION
This is in line with Floki's new feature, that was introduced in https://github.com/philss/floki/pull/467

The initial idea is from https://github.com/philss/floki/issues/463

PS: this removes some unused code, adds `thiserror` as dependency, and refactor a little bit the code.