### PR TITLE
Fix parsing of documents that may contain XML before Doctype

### DIFF
--- a/native/html5ever_nif/src/flat_dom.rs
+++ b/native/html5ever_nif/src/flat_dom.rs
@@ -526,6 +526,8 @@ pub fn flat_sink_to_rec_term<'a>(
         child_base: 0,
         child_n: 0,
     }];
+    let mut comments_bf_doctype = 0u16;
+    let mut read_doctype = false;
 
     loop {
         let mut top = stack.pop().unwrap();
@@ -567,7 +569,9 @@ pub fn flat_sink_to_rec_term<'a>(
                     system_id,
                 } => {
                     assert!(!stack.is_empty());
-                    assert!(child_stack.is_empty());
+                    assert!(child_stack.is_empty() || comments_bf_doctype > 0);
+
+                    read_doctype = true;
 
                     term = (
                         atoms::doctype(),
@@ -596,6 +600,10 @@ pub fn flat_sink_to_rec_term<'a>(
                     term = StrTendrilWrapper(contents).encode(env);
                 }
                 NodeData::Comment { contents } => {
+                    if !read_doctype {
+                        comments_bf_doctype += 1
+                    };
+
                     term = (atoms::comment(), StrTendrilWrapper(contents)).encode(env);
                 }
                 _ => unimplemented!(""),

--- a/test/html5ever_test.exs
+++ b/test/html5ever_test.exs
@@ -308,4 +308,46 @@ defmodule Html5everTest do
                  ]}
               ]}
   end
+
+  test "parse html starting with a XML tag" do
+    html = """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!-- also a comment is allowed -->
+    <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+    <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+      <head><title>Hello</title></head>
+      <body>
+        <a id="anchor" href="https://example.com">link</a>
+      </body>
+    </html>
+    """
+
+    assert Html5ever.parse(html) ==
+             {:ok,
+              [
+                {:comment, "?xml version=\"1.0\" encoding=\"UTF-8\"?"},
+                {:comment, " also a comment is allowed "},
+                {:doctype, "html", "-//W3C//DTD XHTML 1.0 Strict//EN",
+                 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"},
+                {
+                  "html",
+                  [{"xmlns", "http://www.w3.org/1999/xhtml"}, {"xml:lang", "en"}, {"lang", "en"}],
+                  [
+                    {"head", [], [{"title", [], ["Hello"]}]},
+                    "\n",
+                    "  ",
+                    {"body", [],
+                     [
+                       "\n",
+                       "    ",
+                       {"a", [{"id", "anchor"}, {"href", "https://example.com"}], ["link"]},
+                       "\n",
+                       "  ",
+                       "\n",
+                       "\n"
+                     ]}
+                  ]
+                }
+              ]}
+  end
 end


### PR DESCRIPTION
This is a fix for malformed documents that may start with an XML tag, or even a comment before the declaration of the doctype.