### PR TITLE
Update release workflow to remove warnings and fix MacOS outdated versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: Build precompiled NIFs
 
 permissions:
+  # For writing a new release after a tag push.
+  contents: write
+  # For the actions/attest GH Action.
   id-token: write
   attestations: write
-  contents: write
+  artifact-metadata: write
 
 on:
   push:
@@ -36,9 +39,9 @@ jobs:
           - { target: arm-unknown-linux-gnueabihf , os: ubuntu-22.04 , use-cross: true }
           - { target: aarch64-unknown-linux-gnu   , os: ubuntu-22.04 , use-cross: true }
           - { target: aarch64-unknown-linux-musl  , os: ubuntu-22.04 , use-cross: true }
-          - { target: aarch64-apple-darwin        , os: macos-13      }
+          - { target: aarch64-apple-darwin        , os: macos-15      }
           - { target: riscv64gc-unknown-linux-gnu , os: ubuntu-22.04 , use-cross: true }
-          - { target: x86_64-apple-darwin         , os: macos-13      }
+          - { target: x86_64-apple-darwin         , os: macos-15-intel }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-22.04  }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-22.04 , use-cross: true }
           - { target: x86_64-pc-windows-gnu       , os: windows-2022  }
@@ -46,7 +49,7 @@ jobs:
 
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Extract project version
       shell: bash
@@ -62,7 +65,7 @@ jobs:
 
     - name: Build the project
       id: build-crate
-      uses: philss/rustler-precompiled-action@v1.1.4
+      uses: philss/rustler-precompiled-action@v1.1.5
       with:
         project-name: html5ever_nif
         project-version: ${{ env.PROJECT_VERSION }}
@@ -72,12 +75,12 @@ jobs:
         project-dir: "native/html5ever_nif"
 
     - name: Artifact attestation
-      uses: actions/attest-build-provenance@v1
+      uses: actions/attest@v4
       with:
         subject-path: ${{ steps.build-crate.outputs.file-path }}
 
     - name: Artifact upload
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ steps.build-crate.outputs.file-name }}
         path: ${{ steps.build-crate.outputs.file-path }}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -13,23 +13,18 @@ on:
 jobs:
   lint-rust:
     name: Lint Rust
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         manifest:
           - native/html5ever_nif/Cargo.toml
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            native/html5ever_nif
 
       - name: run rustfmt
         run: cargo fmt --manifest-path=${{ matrix.manifest }} --all -- --check


### PR DESCRIPTION
The MacOS 13 image was removed and MacOS 14 is soon to be deprecated, so the version 15 was chosen.

This PR also uses the newer ["actions/attest" GH Action](https://github.com/actions/attest).